### PR TITLE
Set default docker connector to unix:// protocol scheme

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/DockerConnector/config.groovy
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/DockerConnector/config.groovy
@@ -8,7 +8,7 @@ def f = namespace(FormTagLib)
 def c = namespace(CredentialsTagLib)
 
 if (instance == null) {
-    instance = new DockerConnector("http://localhost:2375")
+    instance = new DockerConnector("tcp://localhost:2375")
 }
 
 f.entry(title: _("Docker URL"), field: "serverUrl") {


### PR DESCRIPTION
http:// protocol scheme isn't supported, Only 'tcp://' or 'unix://'
are supported.

Set a sane default, unix:// as it is the default protocol on a basic
docker installation.

It will avoid to get an error message on a fresh installation of the plugin:
Unsupported protocol scheme found: 'http://localhost:2375'. Only 'tcp://'
or 'unix://' supported.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>