### PR TITLE
travis: cache Maven directory for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: java
 
 jdk: oraclejdk8
 
+cache:
+  directories:
+  - $HOME/.m2
+
 before_install:
  - pip install --user codecov
 


### PR DESCRIPTION
See https://docs.travis-ci.com/user/caching/#Arbitrary-directories

You can cache arbitrary directories, such as Gradle, Maven, Composer and
npm cache directories, between builds by listing them in your .travis.yml

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>