### PR TITLE
[Fix] NullPointerException (image.getRepoTags() == null) on some images

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImage.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImage.java
@@ -83,7 +83,8 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
         // if image was specified without tag, then treat as latest
         final String fullImageName = repostag.repos + ":" + (repostag.tag.isEmpty() ? "latest" : repostag.tag);
 
-        boolean hasImage = Iterables.any(images, image -> Arrays.asList(image.getRepoTags()).contains(fullImageName));
+        boolean hasImage = Iterables.any(images, image ->
+                image.getRepoTags() != null && Arrays.asList(image.getRepoTags()).contains(fullImageName));
 
         boolean pull = hasImage ?
                 getPullStrategy().pullIfExists(imageName) :


### PR DESCRIPTION
On some image i get NullPointerException
(I think it comes from the cached images when building an image with Dockerfile, but I'm not sure)
```
java.lang.NullPointerException
	at com.github.kostyasha.yad.commons.DockerPullImage.lambda$exec$0(DockerPullImage.java:88)
	at com.github.kostyasha.yad.docker_java.com.google.common.collect.Iterators.indexOf(Iterators.java:778)
	at com.github.kostyasha.yad.docker_java.com.google.common.collect.Iterators.any(Iterators.java:684)
	at com.github.kostyasha.yad.docker_java.com.google.common.collect.Iterables.any(Iterables.java:623)
	at com.github.kostyasha.yad.commons.DockerPullImage.exec(DockerPullImage.java:86)
	at com.github.kostyasha.yad.DockerCloud.provisionWithWait(DockerCloud.java:191)
	at com.github.kostyasha.yad.DockerCloud.lambda$provision$0(DockerCloud.java:117)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```