### PR TITLE
Improvements to init.sh for running on minimal Alpine Linux/BusyBox slave

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
@@ -44,9 +44,9 @@ cd "$JENKINS_HOME"
 
 # download slave jar
 # TODO some caching mechanism with checksums
-if [[ -x $(command -v wget) ]]; then
+if [[ -x "$(command -v wget)" ]]; then
     wget "${JENKINS_URL}/jnlpJars/slave.jar" -O "slave.jar"
-elif [[ -x $(command -v curl) ]]; then
+elif [[ -x "$(command -v curl)" ]]; then
     curl --remote-name "${JENKINS_URL}/jnlpJars/slave.jar"
 fi
 
@@ -59,10 +59,12 @@ if [ ! -z "$COMPUTER_SECRET" ]; then
  RUN_CMD+=" -secret $COMPUTER_SECRET"
 fi
 
-if [[ -x $(command -v gosu) ]]; then
-    RUN_CMD="gosu $JENKINS_USER $RUN_CMD"
-elif [ ! -z "$JENKINS_USER" ] && [ x"$JENKINS_USER" != "xroot" ]; then
-    RUN_CMD="su - $JENKINS_USER -c '$RUN_CMD'"
+if [[ $(id -nu) != "$JENKINS_USER" ]]; then
+    if [[ -x "$(command -v gosu)" ]]; then
+        RUN_CMD="gosu $JENKINS_USER $RUN_CMD"
+    else
+        RUN_CMD="su - $JENKINS_USER -c '$RUN_CMD'"
+    fi
 fi
 
 eval "$RUN_CMD"

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -uxe
 
@@ -44,9 +44,9 @@ cd "$JENKINS_HOME"
 
 # download slave jar
 # TODO some caching mechanism with checksums
-if [[ -x "$(command -v wget)" ]]; then
+if [ -x "$(command -v wget)" ]; then
     wget "${JENKINS_URL}/jnlpJars/slave.jar" -O "slave.jar"
-elif [[ -x "$(command -v curl)" ]]; then
+elif [ -x "$(command -v curl)" ]; then
     curl --remote-name "${JENKINS_URL}/jnlpJars/slave.jar"
 fi
 
@@ -59,8 +59,8 @@ if [ ! -z "$COMPUTER_SECRET" ]; then
  RUN_CMD+=" -secret $COMPUTER_SECRET"
 fi
 
-if [[ $(id -nu) != "$JENKINS_USER" ]]; then
-    if [[ -x "$(command -v gosu)" ]]; then
+if [ "$(id -nu)" != "$JENKINS_USER" ]; then
+    if [ -x "$(command -v gosu)" ]; then
         RUN_CMD="gosu $JENKINS_USER $RUN_CMD"
     else
         RUN_CMD="su - $JENKINS_USER -c '$RUN_CMD'"

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -uxe
 


### PR DESCRIPTION
I'd like to run with a minimal Alpine Linux (BusyBox) slave, and these changes help somewhat (ideally I would like to remove the dependence on `bash` [700k] completely - BusyBox comes with `sh` and `ash`).

- Make tests for executable commands more robust.  At least with BusyBox `sh`, the quotes are required, otherwise the tests succeed with an empty path (non-existent command).
- Eliminate need for `gosu` or `su` if already running as the correct user (`$JENKINS_URL`).