### PR TITLE
Restore API version help file.

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/DockerConnector/help-apiVersion.html
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/DockerConnector/help-apiVersion.html
@@ -1,1 +1,7 @@
-Docker API version.
+<div>
+    Docker Daemon API version. Should be set when plugin underlying library can't connect to new daemon
+    because docker daemon API become backward incompatible.<br/>
+    Version in format "1.22". Connector will append "/v${VERSION}" to api url for connector,
+    where ${VERSION} is entered string. For details see <a
+        href="https://docs.docker.com/reference/api/docker_remote_api/">docker_remote_api</a>
+</div>


### PR DESCRIPTION
History:
People was confused and it was not clear why it needed so in docker-plugin it was removed.
Now docker API become more not compatible so makes sense restore it for users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/yet-another-docker-plugin/117)
<!-- Reviewable:end -->
