### PR TITLE
Do not require the port binding for the ssh service

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
@@ -74,7 +74,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
             createCmd.withCmd("bash", "-c", "/usr/sbin/sshd -D -p " + sshPort);
         }
 
-        createCmd.getPortBindings().add(PortBinding.parse("0.0.0.0::" + sshPort));
+        createCmd.getPortBindings().add(PortBinding.parse(Integer.toString(sshPort)));
     }
 
     @Override


### PR DESCRIPTION
Do not require the port binding for the ssh service to be on the 0.0.0.0 address.

The problem is that Windows Server 2016 docker implementation does not support "host IP addresses in NAT settings" - Removing the fixed IP solves the problem and makes no problems with *NIX based servers.

This fix was originally submitted to the docker-java project and has been merged, but was never published to the Jenkins plugin repository.

We're using the Windows Server 2016 Docker via a swarm setup and it worked like a charm with the original Docker Plugin. We're using custom images with a cygwin SSHD set up, but I'm trying to port this to at least Open SSH by windows.

It might help to get #151 under way.