### PR TITLE
Windows support for the JNLP connector

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerCloud.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerCloud.java
@@ -166,7 +166,7 @@ public class DockerCloud extends AbstractCloud implements Serializable {
         dockerCreateContainer.fillContainerConfig(containerConfig);
 
         // launcher specific options
-        slaveTemplate.getLauncher().appendContainerConfig(slaveTemplate, containerConfig);
+        slaveTemplate.getLauncher().appendContainerConfig(slaveTemplate, containerConfig, getClient());
 
         // cloud specific options
         appendContainerConfig(slaveTemplate, containerConfig);

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerLauncher.java
@@ -2,6 +2,7 @@ package com.github.kostyasha.yad.launcher;
 
 
 import com.github.kostyasha.yad.DockerSlaveTemplate;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.kostyasha.yad_docker_java.com.google.common.annotations.Beta;
@@ -38,7 +39,8 @@ public abstract class DockerComputerLauncher extends DelegatingComputerLauncher 
      * i.e. port for exposing, command to run, etc.
      */
     public abstract void appendContainerConfig(DockerSlaveTemplate dockerSlaveTemplate,
-                                               CreateContainerCmd createContainerCmd) throws IOException;
+                                               CreateContainerCmd createContainerCmd,
+                                               DockerClient dockerClient) throws IOException;
 
     /**
      * Wait until slave is up and ready for connection.

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
@@ -4,6 +4,7 @@ import com.github.kostyasha.yad.DockerCloud;
 import com.github.kostyasha.yad.DockerSlaveTemplate;
 import com.github.kostyasha.yad.commons.DockerCreateContainer;
 import com.github.kostyasha.yad.utils.HostAndPortChecker;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.ExposedPort;
@@ -63,7 +64,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
     }
 
     @Override
-    public void appendContainerConfig(DockerSlaveTemplate dockerSlaveTemplate, CreateContainerCmd createCmd) {
+    public void appendContainerConfig(DockerSlaveTemplate dockerSlaveTemplate, CreateContainerCmd createCmd, DockerClient dockerClient) {
         final int sshPort = getSshConnector().port;
 
         createCmd.withPortSpecs(sshPort + "/tcp");

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -1,0 +1,63 @@
+$CONFIG="c:\config.ps1"
+
+while ( -not (Test-Path $CONFIG)){
+    Write-Output "No config, sleeping for 1 second"
+    sleep 1
+}
+
+
+Write-Output "Found config file"
+. "$CONFIG"
+# require:
+# $JENKINS_URL
+# $COMPUTER_URL
+# $COMPUTER_SECRET
+
+if (!$JENKINS_URL){
+ echo "JENKINS_URL is not defined! Exiting."
+ exit 1
+}
+
+if (!$COMPUTER_URL){
+ echo "COMPUTER_URL is not defined! Exiting."
+ exit 1
+}
+
+
+# Jenkins not at home - use tmp
+if (-not (Test-Path $JENKINS_HOME)){
+  New-Item -ItemType directory -Path c:\Temp
+  $JENKINS_HOME="c:\Temp"
+}
+
+Write-Output "###################################"
+Write-Output "JENKINS_URL = $JENKINS_URL         "
+Write-Output "JENKINS_USER = $JENKINS_USER       "
+Write-Output "JENKINS_HOME = $JENKINS_HOME       "
+Write-Output "COMPUTER_URL = $COMPUTER_URL       "
+Write-Output "COMPUTER_SECRET = $COMPUTER_SECRET "
+Write-Output "env:CMD_OPTS = $env:CMD_OPTS       "
+Write-Output "SLAVE_OPTS = $SLAVE_OPTS           "
+Write-Output "###################################"
+
+Get-Item Env:
+
+cd "$JENKINS_HOME"
+
+(New-Object System.Net.WebClient).DownloadFile("${JENKINS_URL}/jnlpJars/slave.jar", "${JENKINS_HOME}/slave.jar")
+
+$RUN_CMD="java $env:CMD_OPTS -jar ${JENKINS_HOME}\\slave.jar"
+$RUN_CMD="$RUN_CMD -jnlpUrl ${JENKINS_URL}/${COMPUTER_URL}/slave-agent.jnlp"
+
+# Add Slave Options
+if ( $SLAVE_OPTS ) {
+   $RUN_CMD="$RUN_CMD $SLAVE_OPTS"
+}
+
+# Add Secret
+if ( $COMPUTER_SECRET ) {
+   $RUN_CMD="$RUN_CMD -secret $COMPUTER_SECRET"
+}
+
+Write-Output "RUN_OPTS = $RUN_CMD"
+Invoke-Expression $RUN_CMD

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
@@ -37,7 +37,7 @@ if ! id -u "$JENKINS_USER"; then
     elif [ -x "$(command -v adduser)" ]; then
         adduser -D -h "${JENKINS_HOME}" "$JENKINS_USER"
     else
-        echo "Error: can't add user. useradd or assuser didn't found."
+        echo "Error: can't add user. useradd or adduser didn't found."
     fi
 fi
 


### PR DESCRIPTION
This PR is for #151. It is a port of the docker-java support for windows JNLP clients.

Currently it only supports cloud provider that are windows docker variants, swarm is not yet supported. The connection works the same way as the Linux variant, so a minimal windows docker image with java should be enough to test it.

Maybe @erik-am can have a look at it?