### PR TITLE
Include readTimeout in DockerConnector equals/hashCode

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerConnector.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerConnector.java
@@ -190,6 +190,7 @@ public class DockerConnector extends YADockerConnector {
                 .append(tlsVerify, that.tlsVerify)
                 .append(connectorType, that.connectorType)
                 .append(connectTimeout, that.connectTimeout)
+                .append(readTimeout, that.readTimeout)
                 .isEquals();
     }
 
@@ -202,6 +203,7 @@ public class DockerConnector extends YADockerConnector {
                 .append(tlsVerify)
                 .append(connectorType)
                 .append(connectTimeout)
+                .append(readTimeout)
                 .toHashCode();
     }
 


### PR DESCRIPTION
I have not tried to use this yet, to verify if the behavior I noticed is fixed by the change. Hopefully this fixes #154 where editing the Read Timeout on a Docker connector failed to persist.