### PR TITLE
Expose ssh port automatically without "EXPOSE" command in Dockerfile

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
@@ -65,6 +65,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
     @Override
     public void appendContainerConfig(DockerSlaveTemplate dockerSlaveTemplate, CreateContainerCmd createCmd) {
         final int sshPort = getSshConnector().port;
+        createCmd.withExposedPorts(new ExposedPort(sshPort));
 
         createCmd.withPortSpecs(sshPort + "/tcp");
 


### PR DESCRIPTION
this is SSH Launcher class and had a look to Docker slaves plugin which has this feature too.