### PR TITLE
Random least loaded provisioning strategy

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerCloudLoadComparator.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerCloudLoadComparator.java
@@ -1,0 +1,27 @@
+package com.github.kostyasha.yad.utils;
+
+import com.github.kostyasha.yad.DockerCloud;
+import java.io.Serializable;
+import java.util.Comparator;
+
+import static com.github.kostyasha.yad.utils.DockerFunctions.countCurrentDockerSlaves;
+
+/**
+ * Class used to sort a List of DockerCloud objects by load.  Least loaded is
+ * considered earlier in the sort order.
+ *
+ * @author Sam Gleske (@samrocketman on GitHub)
+ */
+public class DockerCloudLoadComparator implements Comparator<DockerCloud>, Serializable {
+
+    private static final long serialVersionUID = 42L;
+
+    public static long getSerialVersionUID() {
+        return serialVersionUID;
+    }
+
+    @Override
+    public int compare(DockerCloud a1, DockerCloud a2) {
+        return countCurrentDockerSlaves(a1) < countCurrentDockerSlaves(a2) ? -1 : 1;
+    }
+}

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerFunctions.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerFunctions.java
@@ -16,12 +16,12 @@ import hudson.slaves.NodePropertyDescriptor;
 import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import static jenkins.model.Jenkins.getInstance;
 
@@ -90,6 +90,37 @@ public class DockerFunctions {
                 .filter(DockerCloud.class::isInstance)
                 .map(cloud -> (DockerCloud) cloud)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Count the number of current docker slaves for a given DockerCloud.
+     *
+     * @param cloud A DockerCloud.
+     * @return The number of slaves provisioned by the DockerCloud.
+     */
+    public static int countCurrentDockerSlaves(DockerCloud cloud) {
+        try {
+            return cloud.countCurrentDockerSlaves(null);
+        } catch (Exception e) {
+            //an exception was thrown so return an invalid count for current docker slaves
+            return -1;
+        }
+    }
+
+    /**
+     * Get a list of available DockerCloud clouds which are not at max
+     * capacity.
+     *
+     * @param label A label expression of a Job Run requiring an executor.
+     * @return A list of available DockerCloud clouds.
+     */
+    public static List<DockerCloud> getAvailableDockerClouds(Label label) {
+        return getDockerClouds().stream()
+            .filter(cloud ->
+                    cloud.canProvision(label) &&
+                    (countCurrentDockerSlaves(cloud) >= 0) &&
+                    (countCurrentDockerSlaves(cloud) < cloud.getContainerCap()))
+            .collect(Collectors.toList());
     }
 
     public static DockerCloud anyCloudForLabel(Label label) {

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/utils/DockerCloudLoadComparatorTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/utils/DockerCloudLoadComparatorTest.java
@@ -1,0 +1,51 @@
+package com.github.kostyasha.yad.utils;
+
+import com.github.kostyasha.yad.DockerCloud;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Sam Gleske (@samrocketman on GitHub)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DockerCloudLoadComparatorTest {
+
+    @Mock
+    private DockerCloud mockCloudNoLoad;
+    @Mock
+    private DockerCloud mockCloudLoad;
+
+
+    @Test
+    public void testDockerCloudLoadComparison() throws Exception {
+        //cloud with no load
+        when(mockCloudNoLoad.countCurrentDockerSlaves(null)).thenReturn(0);
+        //cloud with load
+        when(mockCloudLoad.countCurrentDockerSlaves(null)).thenReturn(1);
+
+        List<DockerCloud> unsortedClouds = Arrays.asList(mockCloudLoad, mockCloudNoLoad);
+        List<DockerCloud> sortedClouds = Arrays.asList(mockCloudNoLoad, mockCloudLoad);
+
+        //test sorting clouds using the DockerCloudLoadComparator
+        Collections.sort(unsortedClouds, new DockerCloudLoadComparator());
+
+        //unsortedClouds should now be sorted
+        assertThat(sortedClouds, is(unsortedClouds));
+    }
+
+    @Test
+    public void testSerialVersionUID() {
+        //simple test for something which is not used but required by findbugs
+        assertThat(DockerCloudLoadComparator.getSerialVersionUID(), is(42L));
+    }
+}


### PR DESCRIPTION
When Jenkins is configured with more than 10 DockerCloud clouds, yet-another-docker-plugin tends to struggle to provision agents.  Additionally, the first configured cloud is always heavily utilized and the other clouds are not so much.

This proposed change is meant to randomize the selected list of docker clouds and to provision from the least loaded clouds first.  I have thoroughly tested this behavior.

# Scenario

Let's say you have two `DockerCloud` clouds configured (`cloud-01` and `cloud-02`).  Each cloud has a maximum capacity of `2` for the same `DockerSlaveTemplate`.

Now to describe the behavior when two builds populate the Jenkins Queue.

### Old behavior

The old behavior will fill up `cloud-01` with both builds.  `cloud-02` will remain unused.  `cloud-01` will always be exercised and `cloud-02` will process fewer builds.

### New behavior

The new behavior proposed in this change will fill up both `cloud-01` and `cloud-02`.  That's because after the first build is addressed the least loaded cloud is selected.

The selection of least loaded cloud will be random across `cloud-01` and `cloud-02` so over time the serviced build load will be distributed across both clouds more evenly.

# Test this in your own environment

See pre-merge build: https://github.com/samrocketman/yet-another-docker-plugin/releases/tag/0.1.0-rc38-samrocketman-rc1