### PR TITLE
Don't call daemon and exclude redundant pull.

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImage.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImage.java
@@ -10,7 +10,6 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClie
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.PullImageCmd;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Image;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.NameParser;
-import com.github.kostyasha.yad_docker_java.com.google.common.collect.Iterables;
 import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.StringUtils;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -37,6 +36,7 @@ import java.util.List;
 
 import static com.github.kostyasha.yad.client.ClientBuilderForConnector.lookupSystemCredentials;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
@@ -61,8 +61,9 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
     public DockerPullImage() {
     }
 
+    @Nonnull
     public DockerImagePullStrategy getPullStrategy() {
-        return pullStrategy;
+        return isNull(pullStrategy) ? DockerImagePullStrategy.PULL_LATEST : pullStrategy;
     }
 
     @DataBoundSetter
@@ -97,24 +98,10 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
     public void exec(@Nonnull final DockerClient client, @Nonnull final String imageName, TaskListener listener)
             throws IOException {
         PrintStream llog = listener.getLogger();
-        List<Image> images = client.listImagesCmd().exec();
 
-        NameParser.ReposTag repostag = NameParser.parseRepositoryTag(imageName);
-        // if image was specified without tag, then treat as latest
-        final String fullImageName = repostag.repos + ":" + (repostag.tag.isEmpty() ? "latest" : repostag.tag);
-
-        boolean hasImage = Iterables.any(images, image ->
-                image.getRepoTags() != null && Arrays.asList(image.getRepoTags()).contains(fullImageName));
-
-        boolean pull = hasImage ?
-                getPullStrategy().pullIfExists(imageName) :
-                getPullStrategy().pullIfNotExists(imageName);
-
-        if (pull) {
-            LOG.info("Pulling image '{}' {}. This may take awhile...", imageName,
-                    hasImage ? "again" : "since one wasn't pulled before.");
-            llog.println(String.format("Pulling image '%s' %s. This may take awhile...", imageName,
-                    hasImage ? "again" : "since one wasn't pulled before."));
+        if (shouldPullImage(client, imageName)) {
+            LOG.info("Pulling image '{}'. This may take awhile...", imageName);
+            llog.println(String.format("Pulling image '%s'. This may take awhile...", imageName));
 
             long startTime = System.currentTimeMillis();
             final PullImageCmd pullImageCmd = client.pullImageCmd(imageName);
@@ -148,6 +135,36 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
             LOG.info("Finished pulling image '{}', took {} ms", imageName, pullTime);
             llog.println(String.format("Finished pulling image '%s', took %d ms", imageName, pullTime));
         }
+    }
+
+    protected boolean shouldPullImage(DockerClient client, String imageName) {
+        NameParser.ReposTag repostag = NameParser.parseRepositoryTag(imageName);
+
+        // if image was specified without tag, then treat as latest
+        final String fullImageName = repostag.repos + ":" + (repostag.tag.isEmpty() ? "latest" : repostag.tag);
+
+        // simply check without asking docker
+        if (getPullStrategy().pullIfExists(fullImageName) && getPullStrategy().pullIfNotExists(fullImageName)) {
+            return true;
+        }
+
+        if (!getPullStrategy().pullIfExists(fullImageName) && !getPullStrategy().pullIfNotExists(fullImageName)) {
+            return false;
+        }
+
+        List<Image> images = client.listImagesCmd().exec();
+
+        boolean hasImage = images.stream().anyMatch(image ->
+            nonNull(image.getRepoTags()) &&
+                    Arrays.stream(image.getRepoTags())
+                            .anyMatch(repoTag ->
+                                    repoTag.contains(fullImageName) || repoTag.contains("docker.io/" + fullImageName)
+                            )
+        );
+
+        return hasImage ?
+                getPullStrategy().pullIfExists(imageName) :
+                getPullStrategy().pullIfNotExists(imageName);
     }
 
     @Override

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/commons/DockerPullImageTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/commons/DockerPullImageTest.java
@@ -1,0 +1,94 @@
+package com.github.kostyasha.yad.commons;
+
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Image;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static com.github.kostyasha.yad.commons.DockerImagePullStrategy.PULL_ALWAYS;
+import static com.github.kostyasha.yad.commons.DockerImagePullStrategy.PULL_LATEST;
+import static com.github.kostyasha.yad.commons.DockerImagePullStrategy.PULL_NEVER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Slawomir Jaranowski
+ */
+@RunWith(Parameterized.class)
+public class DockerPullImageTest {
+    private final List<Image> imageList;
+    private final String imageName;
+    private final DockerImagePullStrategy pullStrategy;
+    private final boolean shouldPull;
+
+    @Parameterized.Parameters(name = "existing image: ''{0}'', image to pull: ''{1}'', strategy: ''{2}''")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"docker.io/kostyasha/yet-another-docker-plugin:wget-master",
+                        "kostyasha/yet-another-docker-plugin:wget-master", PULL_LATEST, false},
+                {"", "repo/name", PULL_LATEST, true},
+                {"repo/name:latest", "repo/name", PULL_LATEST, true},
+                {"", "repo/name:latest", PULL_LATEST, true},
+                {"repo/name:latest", "repo/name:latest", PULL_LATEST, true},
+                {"", "repo/name:1.0", PULL_LATEST, true},
+                {"repo/name:1.0", "repo/name:1.0", PULL_LATEST, false},
+
+                {"", "repo/name", PULL_ALWAYS, true},
+                {"repo/name:latest", "repo/name", PULL_ALWAYS, true},
+                {"", "repo/name:latest", PULL_ALWAYS, true},
+                {"repo/name:latest", "repo/name:latest", PULL_ALWAYS, true},
+                {"", "repo/name:1.0", PULL_ALWAYS, true},
+                {"repo/name:1.0", "repo/name:1.0", PULL_ALWAYS, true},
+
+                {"", "repo/name", PULL_NEVER, false},
+                {"repo/name:latest", "repo/name", PULL_NEVER, false},
+                {"", "repo/name:latest", PULL_NEVER, false},
+                {"repo/name:latest", "repo/name:latest", PULL_NEVER, false},
+                {"", "repo/name:1.0", PULL_NEVER, false},
+                {"repo/name:1.0", "repo/name:1.0", PULL_NEVER, false},
+
+        });
+    }
+
+    @Test
+    public void shouldPullImageTest() {
+        DockerPullImage dockerPullImage = new DockerPullImage();
+        dockerPullImage.setPullStrategy(pullStrategy);
+        DockerClient client = mockDockerClient();
+        assertEquals(shouldPull, dockerPullImage.shouldPullImage(client, imageName));
+    }
+
+    public DockerPullImageTest(String existedImage, String imageName, DockerImagePullStrategy pullStrategy,
+                               boolean shouldPull) {
+        imageList = Collections.singletonList(mockImage(existedImage));
+        this.imageName = imageName;
+        this.pullStrategy = pullStrategy;
+        this.shouldPull = shouldPull;
+    }
+
+    private DockerClient mockDockerClient() {
+
+        ListImagesCmd listImagesCmd = mock(ListImagesCmd.class);
+
+        when(listImagesCmd.exec()).thenReturn(imageList);
+
+        DockerClient dockerClient = mock(DockerClient.class);
+        when(dockerClient.listImagesCmd()).thenReturn(listImagesCmd);
+
+        return dockerClient;
+    }
+
+    private Image mockImage(String repoTag) {
+        Image img = mock(Image.class);
+        when(img.getRepoTags()).thenReturn(new String[]{repoTag});
+        return img;
+    }
+}


### PR DESCRIPTION
Kudos to @slawekjaranowski  for reducing daemon calls.

Fixed redundant pulling with docker.io prefixes.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/yet-another-docker-plugin/203)
<!-- Reviewable:end -->
