### PR TITLE
Comment out remoteFsMapping, as this causes the script not to execute.

### DIFF
--- a/docs/script-console-scripts/configure-yadocker-cloud.groovy
+++ b/docs/script-console-scripts/configure-yadocker-cloud.groovy
@@ -302,7 +302,7 @@ def newDockerSlaveTemplate(JSONObject obj) {
     dockerSlaveTemplate.setRemoteFs(obj.optString('remote_fs_root', '/srv/jenkins'))
     dockerSlaveTemplate.setMaxCapacity(obj.optInt('max_instances', 10))
     //dockerSlaveTemplate.setRemoteFsMapping(obj.optString('remote_fs_root_mapping'))
-    dockerSlaveTemplate.remoteFsMapping = obj.optString('remote_fs_root_mapping')
+    //dockerSlaveTemplate.remoteFsMapping = obj.optString('remote_fs_root_mapping')
     //define NODE PROPERTIES
     List<NodeProperty> nodeProperties = [] as List<NodeProperty>
     if(obj.optJSONObject('environment_variables')) {


### PR DESCRIPTION
Fixes this error.

YADP Version: 0.1.0-rc42
Jenkins Version: 2.73.1

``` Result

groovy.lang.MissingPropertyException: No such property: remoteFsMapping for class: com.github.kostyasha.yad.DockerSlaveTemplate
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.setProperty(ScriptBytecodeAdapter.java:486)
	at Script1.newDockerSlaveTemplate(Script1.groovy:305)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93) 
```