### PR TITLE
enable specifying the container entrypoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 
     <!-- jenkins plugins identified only by artifactId(!), so keep stupid naming -->
     <modules>
-        <module>yet-another-docker-plugin</module>
         <module>yet-another-docker-java</module>
+        <module>yet-another-docker-plugin</module>
     </modules>
 
     <scm>

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerCreateContainer.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerCreateContainer.java
@@ -71,11 +71,6 @@ public class DockerCreateContainer extends AbstractDescribableImpl<DockerCreateC
     @CheckForNull
     private String command;
 
-    /**
-     * List variant of #command
-     */
-    private List<String> commands;
-
     @CheckForNull
     private String entrypoint;
 
@@ -517,6 +512,11 @@ public class DockerCreateContainer extends AbstractDescribableImpl<DockerCreateC
         String[] cmd = getDockerCommandArray();
         if (cmd.length > 0) {
             containerConfig.withCmd(cmd);
+        }
+
+        String[] entry = getDockerEntrypointArray();
+        if (entry.length > 0) {
+            containerConfig.withEntrypoint(entry);
         }
 
         containerConfig.withPortBindings(Iterables.toArray(getPortMappings(), PortBinding.class));

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/commons/DockerCreateContainer/config.groovy
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/commons/DockerCreateContainer/config.groovy
@@ -14,7 +14,12 @@ if (instance == null) {
 f.advanced(title: _("Create Container settings"), align: "left") {
     f.entry(title: _("Docker Command"), field: "command") {
         f.textarea(name: "command",
-//                class: "fixed-width",
+                'codemirror-mode': 'shell',
+                'codemirror-config': "mode: 'text/x-sh', lineNumbers: true")
+    }
+
+    f.entry(title: _("Docker Entrypoint"), field: "entrypoint") {
+        f.textarea(name: "entrypoint",
                 'codemirror-mode': 'shell',
                 'codemirror-config': "mode: 'text/x-sh', lineNumbers: true")
     }

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/commons/DockerCreateContainer/help-entrypoint.html
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/commons/DockerCreateContainer/help-entrypoint.html
@@ -1,0 +1,3 @@
+<div>
+    The entrypoint to run for this image (leave blank to use the one specified in the image).
+</div>


### PR DESCRIPTION
The field for specifying the entrypoint was already present in the java code but not exposed to the UI and not forwarded to the create container command.