### PR TITLE
Allow container to run as non-root

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher.java
@@ -366,8 +366,7 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
                         "-cxe",
                         "cat << EOF >> /tmp/init.sh && chmod +x /tmp/init.sh && exec /tmp/init.sh\n" +
                                 initCmd.replace("$", "\\$") + "\n" +
-                                "EOF" + "\n")
-                        .withUser("root");
+                                "EOF" + "\n");
             }
         }
 


### PR DESCRIPTION
Fixes #217

I tested this manually and was able to run the container as non-root.  It started with the `jenkins` user.  Verified using `docker inspect` on the started container.