### PR TITLE
Fix wrong handling of java and slave option arguments in powershell script

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -39,7 +39,7 @@ Write-Output "###################################"
 
 $RUN_CMD="java"
 
-if (!$JAVA_OPTS) {
+if ($JAVA_OPTS) {
    $RUN_CMD="$RUN_CMD $JAVA_OPTS"
 }
 
@@ -53,7 +53,7 @@ if ($NO_CERTIFICATE_CHECK -eq "true") {
    $RUN_CMD="$RUN_CMD -noCertificateCheck"
 }
 
-if (!$SLAVE_OPTS) {
+if ($SLAVE_OPTS) {
    $RUN_CMD="$RUN_CMD $SLAVE_OPTS"
 }
 


### PR DESCRIPTION
In the powershell init script there is a wrong if statement.
The configured JAVA_OPTS and SLAVE_OPTS are not added to the _Invoke-Expression_ call