### PR TITLE
Fix wrong handling of java and slave options in powershell script

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -39,7 +39,7 @@ Write-Output "###################################"
 
 $RUN_CMD="java"
 
-if (!$JAVA_OPTS) {
+if ($JAVA_OPTS) {
    $RUN_CMD="$RUN_CMD $JAVA_OPTS"
 }
 
@@ -53,7 +53,7 @@ if ($NO_CERTIFICATE_CHECK -eq "true") {
    $RUN_CMD="$RUN_CMD -noCertificateCheck"
 }
 
-if (!$SLAVE_OPTS) {
+if ($SLAVE_OPTS) {
    $RUN_CMD="$RUN_CMD $SLAVE_OPTS"
 }
 


### PR DESCRIPTION
There was an error in the init.ps1 script for windows container.
JAVA_OPTS and SLAVE_OPTS specified in the configuration are not forwarded to the slave startup.