### PR TITLE
Explicitly set the SecurityProtocol when getting slave.jar

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -67,6 +67,7 @@ cd $JENKINS_HOME
 
 try {
    Write-Output "Invoke-WebRequest -Uri $JENKINS_URL/jnlpJars/slave.jar -Outfile $JENKINS_HOME/slave.jar"
+   [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
    Invoke-WebRequest -Uri "$JENKINS_URL/jnlpJars/slave.jar" -Outfile "$JENKINS_HOME/slave.jar"
 
    Write-Output "$RUN_CMD"


### PR DESCRIPTION
This explicitly allows the current powershell instance to accept TLS2, TLS1 and TLS connections.
This is crucial if Jenkins is hosted with https because otherwise, the docker slaves cannot download the slave.jar from the server unless this security setting is set in the registry of the windows docker container.