### PR TITLE
Add a slave container configuration timeout

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -1,7 +1,13 @@
 $progressPreference = 'silentlyContinue'  # no progress bars
 
+$configTimeout = 60
 $CONFIG="c:\config.ps1"
 while (-not (Test-Path $CONFIG)) {
+   $configTimeout = $configTimeout - 1
+   if ($configTimeout -le 0) {
+      Write-Output "No config file found after 60s! Exiting."
+      exit 1
+   }
    Write-Output "No config, sleeping for 1 second"
    sleep 1
 }

--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.sh
@@ -2,8 +2,14 @@
 
 set -uxe
 
+config_timeout=60
 export CONFIG="/tmp/config.sh"
 while [ ! -f "$CONFIG" ]; do
+    config_timeout=$(($config_timeout-1))
+    if [ $config_timeout -le 0 ]; then
+        echo "No config file found after 60s! Exiting."
+        exit 1
+    fi
     echo "No config, sleeping for 1 second"
     sleep 1
 done


### PR DESCRIPTION
This should fix the following issue.
When a JobDSL seed job is executed while a container is waiting for its
configuration YAD plugin may loose track of the container.
The container is left behind indefinitely waiting for its configuration.

We are using the JobDSL plugin to generate multiple cloud sections in $JENKINS_HOME/config.xml
but the problem arise even when their is no change in the clouds configuration.
I imagine that when the seed job is executed it somehow reload the plugins and the container provisioning task is dropped in midflight.
The "Set exclusive execution" is set in our seed job but that doesn't prevent YAD from provisioning a container while a seed job is running (the provisioning task is not part of any job).

With this change, the container eventually exit in error and the jenkins
master is able to provision another container.

Environment:
Jenkins ver. 2.150.1
Job DSL plugin 1.70
Yet Another Docker Plugin  0.1.0-rc51
