### PR TITLE
Use the registry to enable TLS 1.2 so that Nano Server can be supported.

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -66,12 +66,21 @@ if ($COMPUTER_SECRET) {
 cd $JENKINS_HOME
 
 try {
-   Write-Output "Invoke-WebRequest -Uri $JENKINS_URL/jnlpJars/slave.jar -Outfile $JENKINS_HOME/slave.jar"
-   [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-   Invoke-WebRequest -Uri "$JENKINS_URL/jnlpJars/slave.jar" -Outfile "$JENKINS_HOME/slave.jar"
+   Write-Host "Enabling TLS 1.2 ...";
+   $tls12RegBase = "HKLM:\\\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SCHANNEL\\Protocols\\TLS 1.2";
+   if (Test-Path $tls12RegBase) { throw ("'{0}' already exists!" -f $tls12RegBase) }
+   New-Item -Path ("{0}/Client" -f $tls12RegBase) -Force;
+   New-Item -Path ("{0}/Server" -f $tls12RegBase) -Force;
+   New-ItemProperty -Path ("{0}/Client" -f $tls12RegBase) -Name "DisabledByDefault" -PropertyType DWORD -Value 0 -Force;
+   New-ItemProperty -Path ("{0}/Client" -f $tls12RegBase) -Name "Enabled" -PropertyType DWORD -Value 1 -Force;
+   New-ItemProperty -Path ("{0}/Server" -f $tls12RegBase) -Name "DisabledByDefault" -PropertyType DWORD -Value 0 -Force;
+   New-ItemProperty -Path ("{0}/Server" -f $tls12RegBase) -Name "Enabled" -PropertyType DWORD -Value 1 -Force;
 
-   Write-Output "$RUN_CMD"
-   Invoke-Expression "$RUN_CMD"
+   Write-Output "Invoke-WebRequest -Uri $JENKINS_URL/jnlpJars/slave.jar -Outfile $JENKINS_HOME/slave.jar";
+   Invoke-WebRequest -Uri "$JENKINS_URL/jnlpJars/slave.jar" -Outfile "$JENKINS_HOME/slave.jar";
+
+   Write-Output "$RUN_CMD";
+   Invoke-Expression "$RUN_CMD";
 
    exit 0
 } catch {


### PR DESCRIPTION
Nano Server does not contain the Net.ServicePointManager class, so enabling TLS fails and therefor the Slave does not work at all. By using the registry we can enable TLS without dropping support for Nano Server.

Credits for the code go to a colleague of mine who applied this fix to the [official OpenJDK Docker-repo](https://github.com/docker-library/openjdk/pull/291/commits/2f3905232cb20296e9b20a1f6811eebbe97832ca#diff-bbcf791307f8bae42ac6048b94a27b12R8), I only copied the code here for use in this repository :)