### PR TITLE
Make sure that the config.ps1 is not locked before accessing it from the init.ps1 script.

### DIFF
--- a/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/yet-another-docker-plugin/src/main/resources/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -6,6 +6,35 @@ while (-not (Test-Path $CONFIG)) {
    sleep 1
 }
 
+function Test-FileLock {
+   param (
+      [parameter(Mandatory=$true)]
+      [string]$Path
+   )
+
+   $oFile = New-Object System.IO.FileInfo $Path
+
+   try
+   {
+      $oStream = $oFile.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+      if ($oStream)
+      {
+         $oStream.Close()
+      }
+      $false
+   }
+   catch
+   {
+      # file is locked by a process.
+      $true
+   }
+}
+
+while (Test-FileLock $CONFIG) {
+   Write-Output "Config file is still being created, sleeping for 1 second"
+   sleep 1
+}
+
 Write-Output "Found config file $CONFIG"
 . "$CONFIG"
 


### PR DESCRIPTION
This implements the suggestions I described in detail with Issue #269.
Once merged, this Closes #269 