### PR TITLE
Hoist code from deprecated API to plugin itself

### DIFF
--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSSHLauncher.java
@@ -1,5 +1,6 @@
 package com.github.kostyasha.yad.launcher;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.github.kostyasha.yad.DockerCloud;
 import com.github.kostyasha.yad.DockerSlaveTemplate;
 import com.github.kostyasha.yad.commons.DockerCreateContainer;
@@ -120,8 +121,10 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
             LOG.info("Creating slave SSH launcher for '{}:{}'. Cloud: '{}'. Template: '{}'",
                     hostAndPort.getHostText(), hostAndPort.getPort(), cloudId,
                     template.getDockerContainerLifecycle().getImage());
+            final String credentialsId = sshConnector.getCredentialsId();
+            final StandardUsernameCredentials credentials = SSHLauncher.lookupSystemCredentials(credentialsId);
             return new SSHLauncher(hostAndPort.getHostText(), hostAndPort.getPort(),
-                    sshConnector.getCredentials(),
+                    credentials,
                     sshConnector.jvmOptions,
                     sshConnector.javaPath,
                     sshConnector.prefixStartSlaveCmd,


### PR DESCRIPTION
Deprecated and removed API from the ssh-slaves-plugin did lookup of
credentials from an ID. Moved this lookup into DockerComputerSSHLauncher
to avoid errors after upgrading ssh-slaves-plugin from 1.29.4 to 1.30.x.

Should be a fix for #257. Alternative to #262, which looks to be a much more substantial change moving credentials into the yad-plugin settings.

I was unable to build locally, because my dev environment is using OpenJDK 12, and several things break between Oracle JDK 8 and OpenJDK 12. I tried fixing several by updating versions of plugins and dependencies, but after getting far enough down the rabbit-hole I gave up rather than keep trying to drag the POM into using JDK 12 and/or build a new JDK 8 environment.