### PR TITLE
Modernise plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>6.2211.v27f680c93c53</version>
+        <relativePath/>
     </parent>
 
     <groupId>com.github.kostyasha.yet-another-docker</groupId>
@@ -14,6 +15,14 @@
     <packaging>pom</packaging>
 
     <name>Yet Another Docker Plugin Parent</name>
+    <url>https://github.com/jenkinsci/yet-another-docker-plugin</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -30,203 +39,28 @@
     </modules>
 
     <scm>
-        <connection>scm:git:ssh://github.com/KostyaSha/yet-another-docker-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/KostyaSha/yet-another-docker-plugin.git</developerConnection>
-        <url>https://github.com/KostyaSha/yet-another-docker-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:https://github.com/${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/releases</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
-        <jenkins.version>2.19.4</jenkins.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
-        <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <!--<hpi-plugin.version>1.119</hpi-plugin.version>-->
-        <stapler.version>1.102</stapler.version>
-        <jdk.version>1.8</jdk.version>
-        <java.level>8</java.level>
-        <java.level.test>8</java.level.test>
-        <!-- addional versions -->
-        <matrix-project.version>1.6</matrix-project.version>
-        <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-        <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
-        <docker-commons-plugin.version>1.3.1</docker-commons-plugin.version>
-        <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+        <jenkins.baseline>2.541</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <gitHubRepo>jenkinsci/yet-another-docker-plugin</gitHubRepo>
+        <!-- TODO: fix spotbugs warnings and drop this override -->
+        <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>${maven-javadoc-plugin.version}</version>
-                    <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                            <configuration>
-                                <additionalparam>-Xdoclint:none</additionalparam>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.jenkins-ci.tools</groupId>
-                    <artifactId>maven-hpi-plugin</artifactId>
-                    <version>${hpi-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.kohsuke.stapler</groupId>
-                            <artifactId>stapler</artifactId>
-                            <version>${stapler.version}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.0.0</version>
-                    <executions>
-                        <execution>
-                            <id>checkstyle</id>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <encoding>UTF-8</encoding>
-                        <failOnViolation>true</failOnViolation>
-                        <logViolationsToConsole>true</logViolationsToConsole>
-                        <linkXRef>false</linkXRef>
-                        <configLocation>
-                            src/test/resources/checkstyle/checkstyle-config.xml
-                        </configLocation>
-                        <suppressionsLocation>
-                            src/test/resources/checkstyle/checkstyle-suppressions.xml
-                        </suppressionsLocation>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.5</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.2</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-
-                        <execution>
-                            <id>post-unit-test</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-
-                        <execution>
-                            <id>pre-integration-test</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>prepare-agent-integration</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>report-integration</id>
-                            <goals>
-                                <goal>report-integration</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                    <debug>true</debug>
-                    <optimize>false</optimize>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>jenkins-core</artifactId>
-                <version>${jenkins.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>6715.v52b_c00222d1e</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/yet-another-docker-java/pom.xml
+++ b/yet-another-docker-java/pom.xml
@@ -10,17 +10,11 @@
 
     <name>Yet Another Docker docker-java shaded</name>
 
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/releases/</url>
-        </repository>
-    </distributionManagement>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
         <shade-prefix>com.github.kostyasha.yad_docker_java</shade-prefix>
-        <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <docker-java.version>3.2.0</docker-java.version>
     </properties>
 
@@ -28,18 +22,6 @@
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-kostyasha-maven</id>
-            <name>bintray</name>
-            <url>http://dl.bintray.com/kostyasha/maven</url>
         </repository>
     </repositories>
 
@@ -51,30 +33,38 @@
     </pluginRepositories>
 
     <dependencies>
+        <!-- docker-java and its transitive dependencies are bundled (shaded/relocated) into this
+             artifact. They are marked optional so they are NOT inherited transitively by the
+             consuming plugin, which would otherwise leak conflicting httpclient/guava/etc. versions. -->
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
             <version>${docker-java.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-core</artifactId>
             <version>${docker-java.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-jersey</artifactId>
             <version>${docker-java.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-netty</artifactId>
             <version>${docker-java.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-okhttp</artifactId>
             <version>${docker-java.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -87,33 +77,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>1.7.21</version>
-            <!--<scope>provided</scope>-->
+            <optional>true</optional>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration combine.children="append">
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>[3.1,3.2.5],[3.5.0,)</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/yet-another-docker-plugin/pom.xml
+++ b/yet-another-docker-plugin/pom.xml
@@ -14,7 +14,7 @@
 
     <name>Yet Another Docker Plugin</name>
     <description>Yet Another Docker plugin. Provides docker Cloud provisioning</description>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Yet+Another+Docker+Plugin</url>
+    <url>https://github.com/jenkinsci/yet-another-docker-plugin</url>
 
     <dependencies>
         <dependency>
@@ -32,195 +32,84 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloud-stats</artifactId>
-            <version>0.23</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>${docker-commons-plugin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-            <artifactId>icon-shim</artifactId>
-            <version>1.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.11</version>
             <optional>true</optional>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jucies</artifactId>
-            <version>0.2.0</version>
-            <optional>true</optional>
+            <artifactId>jdk-tool</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-            <scope>provided</scope>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
+        <!-- test -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>${hpi-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.kohsuke.stapler</groupId>
-                        <artifactId>stapler</artifactId>
-                        <version>${stapler.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <artifactId>yet-another-docker-plugin</artifactId>
-                    <dependentWarExcludes>
-                        org.apache.httpcomponents:*,com.google.guava*
-                    </dependentWarExcludes>
-                    <!--<archive>-->
-                        <!--<manifestEntries>-->
-                            <!--<Mask-Classes>com.google.common</Mask-Classes>-->
-                        <!--</manifestEntries>-->
-                    <!--</archive>-->
-                    <!--<maskClasses>com.google.common.</maskClasses>-->
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>display-info</id>
-                        <configuration>
-                            <rules>
-                                <enforceBytecodeVersion>
-                                    <ignoreClasses combine.children="append">
-                                        <ignoreClass>module-info</ignoreClass>
-                                    </ignoreClasses>
-                                </enforceBytecodeVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>yad-plugin-big-run</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>github-pullrequest</artifactId>
-                    <version>0.0.1-beta14</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>ssh-credentials</artifactId>
-                    <version>1.14</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>token-macro</artifactId>
-                    <version>1.7</version>
-                    <optional>true</optional>
-                </dependency>
-                <dependency>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>docker-traceability</artifactId>
-                    <version>1.1</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>yad-plugin-analysis</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                    </plugin>
-
-                    <plugin>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                    </plugin>
-
-                    <plugin>
-                        <artifactId>maven-pmd-plugin</artifactId>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerCloud.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerCloud.java
@@ -12,7 +12,7 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.St
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.DockerException;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Container;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Frame;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.LogContainerResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
 import com.github.kostyasha.yad_docker_java.com.google.common.base.Throwables;
 import com.github.kostyasha.yad_docker_java.javax.ws.rs.ProcessingException;
 import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.StringUtils;
@@ -25,8 +25,7 @@ import hudson.model.Label;
 import hudson.slaves.Cloud;
 import hudson.slaves.NodeProvisioner.PlannedNode;
 import hudson.util.FormValidation;
-import hudson.util.NullStream;
-import hudson.util.StreamTaskListener;
+import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedPlannedNode;
@@ -98,7 +97,8 @@ public class DockerCloud extends AbstractCloud implements Serializable {
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "docker-java uses runtime exceptions")
     @Nonnull
     @Override
-    public synchronized Collection<PlannedNode> provision(@CheckForNull Label label, int excessWorkload) {
+    public synchronized Collection<PlannedNode> provision(CloudState state, int excessWorkload) {
+        final Label label = state.getLabel();
         LOG.info("Asked to provision load: '{}', for: '{}' label", excessWorkload, label);
 
         List<PlannedNode> r = new ArrayList<>(excessWorkload);
@@ -226,7 +226,7 @@ public class DockerCloud extends AbstractCloud implements Serializable {
         final DockerComputerLauncher computerLauncher = template.getLauncher();
 
         //pull image
-        dockerContainerLifecycle.getPullImage().exec(getClient(), imageId, new StreamTaskListener(new NullStream()));
+        dockerContainerLifecycle.getPullImage().exec(getClient(), imageId, TaskListener.NULL);
 
         // set the operating system if it's not already cached
         if (template.getOsType() == null) {
@@ -377,7 +377,7 @@ public class DockerCloud extends AbstractCloud implements Serializable {
 
     //    @CheckForNull
     public static DockerCloud getCloudByName(String name) {
-        final Cloud cloud = Jenkins.getInstance().getCloud(name);
+        final Cloud cloud = Jenkins.get().getCloud(name);
         if (cloud instanceof DockerCloud) {
             return (DockerCloud) cloud;
         }
@@ -441,7 +441,7 @@ public class DockerCloud extends AbstractCloud implements Serializable {
         }
 
         public List<Descriptor> getTemplatesDescriptors() {
-            return Arrays.asList(jenkins.model.Jenkins.getInstance().getDescriptor(DockerSlaveTemplate.class));
+            return Arrays.asList(jenkins.model.Jenkins.get().getDescriptor(DockerSlaveTemplate.class));
         }
 
         @Nonnull
@@ -451,7 +451,7 @@ public class DockerCloud extends AbstractCloud implements Serializable {
         }
     }
 
-    private static class MyLogContainerResultCallback extends LogContainerResultCallback {
+    private static class MyLogContainerResultCallback extends ResultCallback.Adapter<Frame> {
         private ArrayList<String> logLines = new ArrayList<>();
 
         @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING")

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerConnector.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerConnector.java
@@ -14,7 +14,7 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.RemoteApi
 import com.github.kostyasha.yad_docker_java.com.google.common.base.Preconditions;
 import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.StringUtils;
 import com.github.kostyasha.yad_docker_java.org.glassfish.jersey.client.ClientProperties;
-import com.google.common.base.Throwables;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.ItemGroup;
@@ -33,7 +33,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
@@ -161,7 +161,7 @@ public class DockerConnector extends YADockerConnector {
                         .withDockerConnector(this)
                         .build();
             } catch (GeneralSecurityException e) {
-                Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -223,20 +223,15 @@ public class DockerConnector extends YADockerConnector {
 
         @RequirePOST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
-            AccessControlled ac = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
+            AccessControlled ac = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.get());
             if (!ac.hasPermission(Jenkins.ADMINISTER)) {
                 return new ListBoxModel();
             }
 
-            List<StandardCredentials> credentials =
-                    CredentialsProvider.lookupCredentials(StandardCredentials.class,
-                            context,
-                            ACL.SYSTEM,
-                            Collections.emptyList());
-
             return new CredentialsListBoxModel()
                     .includeEmptyValue()
-                    .withMatching(CredentialsMatchers.always(), credentials);
+                    .includeMatchingAs(ACL.SYSTEM2, context, StandardCredentials.class,
+                            Collections.emptyList(), CredentialsMatchers.always());
         }
 
         @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "docker-java uses runtime exceptions")

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerContainerLifecycle.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerContainerLifecycle.java
@@ -5,8 +5,9 @@ import com.github.kostyasha.yad.commons.DockerPullImage;
 import com.github.kostyasha.yad.commons.DockerRemoveContainer;
 import com.github.kostyasha.yad.commons.DockerStopContainer;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -27,7 +28,7 @@ import static java.util.Objects.nonNull;
  *
  * @author Kanstantsin Shautsou
  */
-public class DockerContainerLifecycle extends AbstractDescribableImpl<DockerContainerLifecycle> {
+public class DockerContainerLifecycle implements Describable<DockerContainerLifecycle> {
 
     private String image = "";
 
@@ -41,6 +42,11 @@ public class DockerContainerLifecycle extends AbstractDescribableImpl<DockerCont
 
     @DataBoundConstructor
     public DockerContainerLifecycle() {
+    }
+
+    @Override
+    public Descriptor<DockerContainerLifecycle> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     // image

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerGlobalConfiguration.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerGlobalConfiguration.java
@@ -23,14 +23,14 @@ public class DockerGlobalConfiguration extends GlobalConfiguration {
     }
 
     public void setCloudOrder(DockerCloudOrder cloudOrder) {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         this.cloudOrder = cloudOrder;
         save();
     }
 
     public static DockerGlobalConfiguration dockerGlobalConfig() {
-        return Jenkins.getInstance().getInjector().getInstance(DockerGlobalConfiguration.class);
+        return Jenkins.get().getInjector().getInstance(DockerGlobalConfiguration.class);
     }
 
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerProvisioningStrategy.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerProvisioningStrategy.java
@@ -88,7 +88,8 @@ public class DockerProvisioningStrategy extends NodeProvisioner.Strategy {
 
                 if (availableCapacity < currentDemand) {
                     // may happen that would be provisioned with other template
-                    Collection<PlannedNode> plannedNodes = dockerCloud.provision(label, currentDemand - availableCapacity);
+                    Collection<PlannedNode> plannedNodes = dockerCloud.provision(
+                            new hudson.slaves.Cloud.CloudState(label, 0), currentDemand - availableCapacity);
                     LOG.debug("Planned {} new nodes", plannedNodes.size());
 
                     strategyState.recordPendingLaunches(plannedNodes);

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSimpleBuildWrapper.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSimpleBuildWrapper.java
@@ -91,7 +91,7 @@ public class DockerSimpleBuildWrapper extends SimpleBuildWrapper {
 
             jenkinsAddNodeWithRetry(getDockerSlaveSingleWithRetry(run, activityId, futureName));
 
-            final Node futureNode = Jenkins.getInstance().getNode(futureName);
+            final Node futureNode = Jenkins.get().getNode(futureName);
             if (!(futureNode instanceof DockerSlaveSingle)) {
                 logger.println("Can't get node" + futureName);
                 throw new IllegalStateException("Can't get Node " + futureName);
@@ -176,7 +176,7 @@ public class DockerSimpleBuildWrapper extends SimpleBuildWrapper {
 
             LOG.info("Shutting down slave");
             logger.println("Shutting down slave '" + slaveName + "'.");
-            final Node slaveNode = Jenkins.getInstance().getNode(slaveName);
+            final Node slaveNode = Jenkins.get().getNode(slaveName);
             if (isNull(slaveNode)) {
                 throw new IllegalStateException("Can't get node " + slaveName);
             }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSlave.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSlave.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.cloudstats.CloudStatistics;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedItem;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,16 +66,13 @@ public class DockerSlave extends AbstractCloudSlave implements TrackedItem {
     public DockerSlave(String slaveName, String nodeDescription, ComputerLauncher launcher, String containerId,
                        DockerSlaveTemplate dockerSlaveTemplate, String cloudId, ProvisioningActivity.Id provisioningId)
             throws IOException, Descriptor.FormException {
-        super(slaveName,
-                nodeDescription, //description
-                dockerSlaveTemplate.getRemoteFs(),
-                dockerSlaveTemplate.getNumExecutors(),
-                dockerSlaveTemplate.getMode(),
-                dockerSlaveTemplate.getLabelString(),
-                launcher,
-                dockerSlaveTemplate.getRetentionStrategyCopy(),
-                dockerSlaveTemplate.getNodeProperties()
-        );
+        super(slaveName, dockerSlaveTemplate.getRemoteFs(), launcher);
+        setNodeDescription(nodeDescription);
+        setNumExecutors(dockerSlaveTemplate.getNumExecutors());
+        setMode(dockerSlaveTemplate.getMode());
+        setLabelString(dockerSlaveTemplate.getLabelString());
+        setRetentionStrategy(dockerSlaveTemplate.getRetentionStrategyCopy());
+        setNodeProperties(dockerSlaveTemplate.getNodeProperties());
         this.displayName = slaveName; // initial value
         this.containerId = containerId;
         this.cloudId = cloudId;
@@ -101,7 +98,7 @@ public class DockerSlave extends AbstractCloudSlave implements TrackedItem {
 
     @Nonnull
     public DockerCloud getCloud() {
-        final Cloud cloud = Jenkins.getInstance().getCloud(getCloudId());
+        final Cloud cloud = Jenkins.get().getCloud(getCloudId());
 
         if (cloud == null) {
             throw new RuntimeException("Docker template " + dockerSlaveTemplate + " has no assigned Cloud.");
@@ -144,7 +141,7 @@ public class DockerSlave extends AbstractCloudSlave implements TrackedItem {
     }
 
     @Override
-    public Node reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+    public Node reconfigure(StaplerRequest2 req, JSONObject form) throws Descriptor.FormException {
         return null;
     }
 

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSlaveConfig.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSlaveConfig.java
@@ -5,7 +5,8 @@ import com.github.kostyasha.yad.strategy.DockerOnceRetentionStrategy;
 import com.github.kostyasha.yad_docker_java.com.google.common.base.Strings;
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.slaves.ComputerLauncher;
@@ -31,7 +32,7 @@ import static java.util.UUID.randomUUID;
  *
  * @author Kanstantsin Shautsou
  */
-public class DockerSlaveConfig extends AbstractDescribableImpl<DockerSlaveConfig> {
+public class DockerSlaveConfig implements Describable<DockerSlaveConfig> {
     /**
      * Unique id of this template configuration. Required for:
      * - hashcode,
@@ -178,6 +179,12 @@ public class DockerSlaveConfig extends AbstractDescribableImpl<DockerSlaveConfig
             .append(dockerContainerLifecycle, that.dockerContainerLifecycle)
 //            .append(nodeProperties, that.nodeProperties)
             .isEquals();
+    }
+
+
+    @Override
+    public Descriptor<DockerSlaveConfig> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     @Extension

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSlaveSingle.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/DockerSlaveSingle.java
@@ -50,10 +50,13 @@ public class DockerSlaveSingle extends AbstractCloudSlave implements TrackedItem
                              @Nonnull YADockerConnector connector,
                              @Nonnull ProvisioningActivity.Id activityId)
             throws IOException, Descriptor.FormException {
-        super(name, nodeDescription,
-                config.getRemoteFs(), config.getNumExecutors(), config.getMode(),
-                "",
-                config.getLauncher(), config.getRetentionStrategy(), config.getNodeProperties());
+        super(name, config.getRemoteFs(), config.getLauncher());
+        setNodeDescription(nodeDescription);
+        setNumExecutors(config.getNumExecutors());
+        setMode(config.getMode());
+        setLabelString("");
+        setRetentionStrategy(config.getRetentionStrategy());
+        setNodeProperties(config.getNodeProperties());
         this.connector = connector;
         this.activityId = activityId;
         this.config = config;
@@ -101,7 +104,7 @@ public class DockerSlaveSingle extends AbstractCloudSlave implements TrackedItem
             _terminate(getListener());
         } finally {
             try {
-                Jenkins.getInstance().removeNode(this);
+                Jenkins.get().removeNode(this);
             } catch (IOException e) {
                 LOG.warn("Failed to remove {}", name, e);
                 getListener().error("Failed to remove " + name);

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/client/ClientBuilderForConnector.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/client/ClientBuilderForConnector.java
@@ -34,10 +34,9 @@ import java.security.UnrecoverableKeyException;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.firstOrNull;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
-import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
+import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentialsInItemGroup;
 import static com.github.kostyasha.yad.other.ConnectorType.JERSEY;
 import static com.github.kostyasha.yad.other.ConnectorType.OKHTTP;
-import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
@@ -160,7 +159,7 @@ public class ClientBuilderForConnector {
             final DockerServerCredentials dockerCreds = (DockerServerCredentials) credentials;
 
             withSslConfig(new VariableSSLConfig(
-                    dockerCreds.getClientKey(),
+                    dockerCreds.getClientKeySecret().getPlainText(),
                     dockerCreds.getClientCertificate(),
                     dockerCreds.getServerCaCertificate()
             ));
@@ -233,11 +232,10 @@ public class ClientBuilderForConnector {
      */
     public static Credentials lookupSystemCredentials(String credentialsId) {
         return firstOrNull(
-                lookupCredentials(
+                lookupCredentialsInItemGroup(
                         Credentials.class,
-                        Jenkins.getInstance(),
-                        ACL.SYSTEM,
-                        emptyList()
+                        Jenkins.get(),
+                        ACL.SYSTEM2
                 ),
                 withId(credentialsId)
         );

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/AbstractCloud.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/AbstractCloud.java
@@ -50,8 +50,8 @@ public abstract class AbstractCloud extends Cloud {
     }
 
     @Override
-    public boolean canProvision(Label label) {
-        return getTemplate(label) != null;
+    public boolean canProvision(CloudState state) {
+        return getTemplate(state.getLabel()) != null;
     }
 
     @CheckForNull

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerAuthConfigs.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerAuthConfigs.java
@@ -2,7 +2,9 @@ package com.github.kostyasha.yad.commons;
 
 import com.github.kostyasha.yad.commons.cmds.DockerBuildImage;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.AuthConfigurations;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
+import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +16,7 @@ import java.util.List;
 /**
  * @author Kanstantsin Shautsou
  */
-public class DockerAuthConfigs extends AbstractDescribableImpl<DockerAuthConfigs> {
+public class DockerAuthConfigs implements Describable<DockerAuthConfigs> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerBuildImage.class);
 
     private List<DockerAuthConfig> dockerAuthConfigs;
@@ -44,4 +46,10 @@ public class DockerAuthConfigs extends AbstractDescribableImpl<DockerAuthConfigs
         }
         return authConfigurations;
     }
+
+    @Override
+    public Descriptor<DockerAuthConfigs> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerContainerRestartPolicy.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerContainerRestartPolicy.java
@@ -2,7 +2,8 @@ package com.github.kostyasha.yad.commons;
 
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.RestartPolicy;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -22,7 +23,7 @@ import static org.apache.commons.lang.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 /**
  * @author Kanstantsin Shautsou
  */
-public class DockerContainerRestartPolicy extends AbstractDescribableImpl<DockerContainerRestartPolicy> {
+public class DockerContainerRestartPolicy implements Describable<DockerContainerRestartPolicy> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerContainerRestartPolicy.class);
 
     @CheckForNull
@@ -78,6 +79,12 @@ public class DockerContainerRestartPolicy extends AbstractDescribableImpl<Docker
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+
+    @Override
+    public Descriptor<DockerContainerRestartPolicy> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     @Extension

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerCreateContainer.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerCreateContainer.java
@@ -1,7 +1,7 @@
 package com.github.kostyasha.yad.commons;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.CreateContainerCmd;
@@ -19,7 +19,7 @@ import com.github.kostyasha.yad_docker_java.com.google.common.collect.Iterables;
 import com.trilead.ssh2.Connection;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.ItemGroup;
 import hudson.plugins.sshslaves.SSHLauncher;
@@ -68,7 +68,7 @@ import static org.apache.commons.lang.builder.ToStringStyle.SHORT_PREFIX_STYLE;
  * @see com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.CreateContainerCmdImpl
  */
 @DockerCmd
-public class DockerCreateContainer extends AbstractDescribableImpl<DockerCreateContainer> {
+public class DockerCreateContainer implements Describable<DockerCreateContainer> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerCreateContainer.class);
 
     /**
@@ -722,6 +722,12 @@ public class DockerCreateContainer extends AbstractDescribableImpl<DockerCreateC
         return dockerCommandArray;
     }
 
+
+    @Override
+    public Descriptor<DockerCreateContainer> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<DockerCreateContainer> {
 
@@ -807,19 +813,15 @@ public class DockerCreateContainer extends AbstractDescribableImpl<DockerCreateC
         }
 
         public static ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
-            AccessControlled ac = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
+            AccessControlled ac = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.get());
             if (!ac.hasPermission(Jenkins.ADMINISTER)) {
                 return new ListBoxModel();
             }
 
-            return new SSHUserListBoxModel().withMatching(
-                    SSHAuthenticator.matcher(Connection.class),
-                    CredentialsProvider.lookupCredentials(
-                            StandardUsernameCredentials.class,
-                            context,
-                            ACL.SYSTEM,
-                            SSHLauncher.SSH_SCHEME)
-            );
+            return new StandardUsernameListBoxModel()
+                    .includeMatchingAs(ACL.SYSTEM2, context, StandardUsernameCredentials.class,
+                            Collections.singletonList(SSHLauncher.SSH_SCHEME),
+                            SSHAuthenticator.matcher(Connection.class));
         }
 
         @Nonnull

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImage.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImage.java
@@ -15,7 +15,8 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Imag
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.NameParser;
 import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.StringUtils;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
@@ -50,7 +51,7 @@ import static org.apache.commons.lang.builder.ToStringStyle.SHORT_PREFIX_STYLE;
  * @author Kanstantsin Shautsou
  */
 @DockerCmd
-public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
+public class DockerPullImage implements Describable<DockerPullImage> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerPullImage.class);
 
     @CheckForNull
@@ -163,7 +164,7 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
             try {
                 pullImageCmd
                             .exec(new DockerPullImageListenerLogger(listener))
-                        .awaitSuccess();
+                        .awaitCompletion();
             } catch (DockerClientException exception) {
                 String exMsg = exception.getMessage();
                 if (exMsg.contains("Could not pull image: Digest:") ||
@@ -176,6 +177,9 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
                 } else {
                     throw exception;
                 }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while pulling image '" + imageName + "'", e);
             }
 
             long pullTime = System.currentTimeMillis() - startTime;
@@ -229,6 +233,12 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
         return HashCodeBuilder.reflectionHashCode(this);
     }
 
+
+    @Override
+    public Descriptor<DockerPullImage> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<DockerPullImage> {
         @Nonnull
@@ -238,12 +248,10 @@ public class DockerPullImage extends AbstractDescribableImpl<DockerPullImage> {
         }
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
-            List<DockerRegistryAuthCredentials> credentials =
-                    CredentialsProvider.lookupCredentials(DockerRegistryAuthCredentials.class, context, ACL.SYSTEM,
-                            Collections.emptyList());
-
-            return new StandardListBoxModel().withEmptySelection()
-                    .withMatching(CredentialsMatchers.instanceOf(DockerRegistryAuthCredentials.class), credentials);
+            return new StandardListBoxModel().includeEmptyValue()
+                    .includeMatchingAs(ACL.SYSTEM2, context, DockerRegistryAuthCredentials.class,
+                            Collections.emptyList(),
+                            CredentialsMatchers.instanceOf(DockerRegistryAuthCredentials.class));
         }
     }
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImageListenerLogger.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerPullImageListenerLogger.java
@@ -1,7 +1,7 @@
 package com.github.kostyasha.yad.commons;
 
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.PullResponseItem;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.PullImageResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
 import hudson.model.TaskListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +13,7 @@ import static java.util.Objects.nonNull;
 /**
  * @author Kanstantsin Shautsou
  */
-public class DockerPullImageListenerLogger extends PullImageResultCallback {
+public class DockerPullImageListenerLogger extends ResultCallback.Adapter<PullResponseItem> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerPullImageListenerLogger.class);
 
     private TaskListener listener;

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerRegistryCredential.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerRegistryCredential.java
@@ -9,7 +9,8 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.github.kostyasha.yad.credentials.DockerRegistryAuthCredentials;
 import com.github.kostyasha.yad.utils.CredentialsListBoxModel;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import hudson.model.ItemGroup;
 import hudson.security.ACL;
@@ -26,7 +27,7 @@ import java.util.List;
  *
  * @author Kanstantsin Shautsou
  */
-public class DockerRegistryCredential extends AbstractDescribableImpl<DockerRegistryCredential> {
+public class DockerRegistryCredential implements Describable<DockerRegistryCredential> {
 
     private final String registryAddr;
     private final String credentialsId;
@@ -45,17 +46,20 @@ public class DockerRegistryCredential extends AbstractDescribableImpl<DockerRegi
         return credentialsId;
     }
 
+
+    @Override
+    public Descriptor<DockerRegistryCredential> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<DockerRegistryCredential> {
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
-            List<DockerRegistryAuthCredentials> credentials =
-                    CredentialsProvider.lookupCredentials(DockerRegistryAuthCredentials.class, context, ACL.SYSTEM,
-                            Collections.emptyList());
-
             return new CredentialsListBoxModel()
                     .includeEmptyValue()
-                    .withMatching(CredentialsMatchers.always(), credentials);
+                    .includeMatchingAs(ACL.SYSTEM2, context, DockerRegistryAuthCredentials.class,
+                            Collections.emptyList(), CredentialsMatchers.always());
         }
 
         @Nonnull

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerRemoveContainer.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerRemoveContainer.java
@@ -4,7 +4,8 @@ import com.github.kostyasha.yad.connector.YADockerConnector;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.RemoveContainerCmdImpl;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -26,7 +27,7 @@ import static org.apache.commons.lang.builder.ToStringStyle.SHORT_PREFIX_STYLE;
  * @see RemoveContainerCmdImpl
  */
 @DockerCmd
-public class DockerRemoveContainer extends AbstractDescribableImpl<DockerRemoveContainer> implements Serializable {
+public class DockerRemoveContainer implements Describable<DockerRemoveContainer>, Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(DockerRemoveContainer.class);
     private static final long serialVersionUID = 1L;
 
@@ -102,6 +103,12 @@ public class DockerRemoveContainer extends AbstractDescribableImpl<DockerRemoveC
         return HashCodeBuilder.reflectionHashCode(this);
     }
 
+
+
+    @Override
+    public Descriptor<DockerRemoveContainer> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
+    }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<DockerRemoveContainer> {

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerSSHConnector.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerSSHConnector.java
@@ -29,6 +29,8 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 import static hudson.Util.fixEmpty;
+import java.util.Collections;
+
 import static hudson.plugins.sshslaves.SSHLauncher.SSH_SCHEME;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -230,13 +232,14 @@ public class DockerSSHConnector extends ComputerConnector {
                     return new ListBoxModel();
                 }
             } else {
-                if (!Jenkins.getInstance().hasPermission(Computer.CONFIGURE)) {
+                if (!Jenkins.get().hasPermission(Computer.CONFIGURE)) {
                     return new ListBoxModel();
                 }
             }
-            return new StandardUsernameListBoxModel().withMatching(SSHAuthenticator.matcher(Connection.class),
-                    CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context,
-                            ACL.SYSTEM, SSH_SCHEME));
+            return new StandardUsernameListBoxModel()
+                    .includeMatchingAs(ACL.SYSTEM2, context, StandardUsernameCredentials.class,
+                            Collections.singletonList(SSH_SCHEME),
+                            SSHAuthenticator.matcher(Connection.class));
         }
 
         public FormValidation doCheckLaunchTimeoutSeconds(String value) {

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerStopContainer.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/DockerStopContainer.java
@@ -4,7 +4,8 @@ import com.github.kostyasha.yad.connector.YADockerConnector;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.StopContainerCmdImpl;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -27,7 +28,7 @@ import static org.apache.commons.lang.builder.ToStringStyle.SHORT_PREFIX_STYLE;
  * @see StopContainerCmdImpl
  */
 @DockerCmd
-public class DockerStopContainer extends AbstractDescribableImpl<DockerStopContainer> implements Serializable {
+public class DockerStopContainer implements Describable<DockerStopContainer>, Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(DockerStopContainer.class);
     private static final long serialVersionUID = 1L;
 
@@ -95,6 +96,12 @@ public class DockerStopContainer extends AbstractDescribableImpl<DockerStopConta
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+
+    @Override
+    public Descriptor<DockerStopContainer> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     @Extension

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/cmds/DockerBuildImage.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/commons/cmds/DockerBuildImage.java
@@ -17,7 +17,8 @@ import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.builder.Hash
 import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.builder.ToStringBuilder;
 import com.github.kostyasha.yad_docker_java.org.apache.http.auth.UsernamePasswordCredentials;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -43,7 +44,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
  */
 @DockerCmd
 @Beta
-public class DockerBuildImage extends AbstractDescribableImpl<DockerBuildImage> implements Serializable {
+public class DockerBuildImage implements Describable<DockerBuildImage>, Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(DockerBuildImage.class);
 
@@ -311,6 +312,12 @@ public class DockerBuildImage extends AbstractDescribableImpl<DockerBuildImage> 
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+
+    @Override
+    public Descriptor<DockerBuildImage> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     @Extension

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/connector/CloudNameDockerConnector.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/connector/CloudNameDockerConnector.java
@@ -43,7 +43,7 @@ public class CloudNameDockerConnector extends YADockerConnector {
     @CheckForNull
     @Override
     public DockerClient getClient() {
-        final Cloud cloud = Jenkins.getInstance().getCloud(cloudName);
+        final Cloud cloud = Jenkins.get().getCloud(cloudName);
         if (cloud instanceof DockerCloud) {
             final DockerCloud dockerCloud = (DockerCloud) cloud;
             return dockerCloud.getClient();
@@ -55,7 +55,7 @@ public class CloudNameDockerConnector extends YADockerConnector {
     public static class DescriptorImpl extends YADockerConnectorDescriptor {
         public FormValidation doCheckCloudName(@QueryParameter String cloudName) {
             try {
-                final Cloud cloud = Jenkins.getInstance().getCloud(cloudName);
+                final Cloud cloud = Jenkins.get().getCloud(cloudName);
                 if (cloud instanceof DockerCloud) {
                     final DockerCloud dockerCloud = (DockerCloud) cloud;
                     Version verResult = dockerCloud.getConnector().getClient().versionCmd().exec();
@@ -71,7 +71,7 @@ public class CloudNameDockerConnector extends YADockerConnector {
 
         public ListBoxModel doFillCloudNameItems() {
             ListBoxModel items = new ListBoxModel();
-            Jenkins.getInstance().clouds.getAll(DockerCloud.class)
+            Jenkins.get().clouds.getAll(DockerCloud.class)
                 .forEach(dockerCloud ->
                     items.add(dockerCloud.getDisplayName())
                 );

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/connector/YADockerConnector.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/connector/YADockerConnector.java
@@ -3,7 +3,7 @@ package com.github.kostyasha.yad.connector;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
@@ -15,20 +15,19 @@ import java.io.Serializable;
  *
  * @author Kanstantsin Shautsou
  */
-public abstract class YADockerConnector extends AbstractDescribableImpl<YADockerConnector>
-        implements ExtensionPoint, Serializable {
+public abstract class YADockerConnector implements Describable<YADockerConnector>, ExtensionPoint, Serializable {
     private static final long serialVersionUID = 1L;
 
     public abstract DockerClient getClient() throws Exception;
 
     @Override
     public YADockerConnectorDescriptor getDescriptor() {
-        return (YADockerConnectorDescriptor) super.getDescriptor();
+        return (YADockerConnectorDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     public abstract static class YADockerConnectorDescriptor extends Descriptor<YADockerConnector> {
         public static DescriptorExtensionList<YADockerConnector, YADockerConnectorDescriptor> allDockerConnectorDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(YADockerConnector.class);
+            return Jenkins.get().getDescriptorList(YADockerConnector.class);
         }
     }
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/credentials/DockerDaemonFileCredentials.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/credentials/DockerDaemonFileCredentials.java
@@ -2,7 +2,6 @@ package com.github.kostyasha.yad.credentials;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
-import com.google.common.base.Throwables;
 import hudson.Extension;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
@@ -41,7 +40,7 @@ public class DockerDaemonFileCredentials extends BaseStandardCredentials impleme
 
     public String getClientKey() {
         resolveCredentialsOnSlave();
-        return credentials.getClientKey();
+        return credentials.getClientKeySecret().getPlainText();
     }
 
     public String getClientCertificate() {
@@ -64,13 +63,14 @@ public class DockerDaemonFileCredentials extends BaseStandardCredentials impleme
             throw new IllegalStateException(dockerCertPath + " isn't directory!");
         }
         try {
-            String caPem = FileUtils.readFileToString(new File(credDir, "ca.pem"));
-            String keyPem = FileUtils.readFileToString(new File(credDir, "key.pem"));
-            String certPem = FileUtils.readFileToString(new File(credDir, "cert.pem"));
-            this.credentials = new DockerServerCredentials(null, "remote-docker", null, caPem, keyPem, certPem);
+            String caPem = FileUtils.readFileToString(new File(credDir, "ca.pem"), java.nio.charset.StandardCharsets.UTF_8);
+            String keyPem = FileUtils.readFileToString(new File(credDir, "key.pem"), java.nio.charset.StandardCharsets.UTF_8);
+            String certPem = FileUtils.readFileToString(new File(credDir, "cert.pem"), java.nio.charset.StandardCharsets.UTF_8);
+            this.credentials = new DockerServerCredentials(null, "remote-docker", null,
+                    hudson.util.Secret.fromString(caPem), keyPem, certPem);
         } catch (IOException ex) {
             LOG.error("", ex);
-            Throwables.propagate(ex);
+            throw new RuntimeException(ex);
         }
     }
 

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/credentials/DockerRegistryAuthCredentials.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/credentials/DockerRegistryAuthCredentials.java
@@ -34,7 +34,7 @@ public class DockerRegistryAuthCredentials extends UsernamePasswordCredentialsIm
                                          @CheckForNull String description,
                                          @CheckForNull String username,
                                          @CheckForNull String password,
-                                         @CheckForNull String email) {
+                                         @CheckForNull String email) throws hudson.model.Descriptor.FormException {
         super(scope, id, description, username, password);
         this.email = Util.fixNull(email);
     }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/credentials/DockerRegistryAuthTokenSource.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/credentials/DockerRegistryAuthTokenSource.java
@@ -3,7 +3,7 @@ package com.github.kostyasha.yad.credentials;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.Charsets;
+import java.nio.charset.StandardCharsets;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
 
 import javax.annotation.Nonnull;
@@ -22,6 +22,6 @@ public class DockerRegistryAuthTokenSource
     public DockerRegistryToken convert(@Nonnull DockerRegistryAuthCredentials c) throws AuthenticationTokenException {
         return new DockerRegistryToken(c.getEmail(),
                 Base64.encodeBase64String((c.getUsername() + ":" + c.getPassword().getPlainText())
-                        .getBytes(Charsets.UTF_8)));
+                        .getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerIOLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerIOLauncher.java
@@ -11,9 +11,8 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.Ex
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Frame;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.StreamType;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.AttachContainerResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
 import com.github.kostyasha.yad_docker_java.org.apache.commons.lang.StringUtils;
-import com.google.common.base.Throwables;
 import hudson.Extension;
 import hudson.model.Slave;
 import hudson.model.TaskListener;
@@ -81,7 +80,7 @@ public class DockerComputerIOLauncher extends DockerComputerLauncher {
              TarArchiveOutputStream tarOut = new TarArchiveOutputStream(byteArrayOutputStream)) {
 
             // @see hudson.model.Slave.JnlpJar.getURL()
-//            byte[] slavejar = IOUtils.toByteArray(Jenkins.getInstance().servletContext.getResourceAsStream("/WEB-INF/slave.jar"));
+//            byte[] slavejar = IOUtils.toByteArray(Jenkins.get().servletContext.getResourceAsStream("/WEB-INF/slave.jar"));
 //            if (isNull(null)) {
 //                // during the development this path doesn't have the files.
 //                slavejar = Files.readAllBytes(Paths.get("./target/jenkins/WEB-INF/slave.jar"));
@@ -173,13 +172,13 @@ public class DockerComputerIOLauncher extends DockerComputerLauncher {
                 try {
                     callback.close();
                 } catch (IOException e) {
-                    Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         });
     }
 
-    private static final class IOCallback extends AttachContainerResultCallback {
+    private static final class IOCallback extends ResultCallback.Adapter<Frame> {
         private TaskListener listener;
         private OutputStream outputStream;
 
@@ -204,7 +203,7 @@ public class DockerComputerIOLauncher extends DockerComputerLauncher {
                     outputStream.flush();
                 } catch (IOException e) {
                     listener.error("Can't write container stdout to channel");
-                    Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
             super.onNext(item);

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerJNLPLauncher.java
@@ -10,7 +10,8 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.Cr
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.NotFoundException;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.ExecStartResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Frame;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -18,9 +19,9 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.DelegatingComputerLauncher;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.Charsets;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -182,7 +183,7 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
         final DockerSlaveTemplate dockerSlaveTemplate = node.getDockerSlaveTemplate();
         final DockerComputerJNLPLauncher launcher = (DockerComputerJNLPLauncher) dockerSlaveTemplate.getLauncher();
 
-        final String rootUrl = launcher.getJenkinsUrl(Jenkins.getInstance().getRootUrl());
+        final String rootUrl = launcher.getJenkinsUrl(Jenkins.get().getRootUrl());
 //        Objects.requireNonNull(rootUrl, "Jenkins root url is not specified!");
         if (isNull(rootUrl)) {
             throw new IllegalStateException("Jenkins root url is not specified!");
@@ -244,11 +245,17 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
             LOG.info("Starting connection command for {}...", containerId);
             logger.println("Starting connection command for " + containerId);
 
-            try (ExecStartResultCallback exec = client
+            try (ResultCallback.Adapter<Frame> exec = client
                     .execStartCmd(response.getId())
                     .withDetach(true)
                     .withTty(true)
-                    .exec(new ExecStartResultCallback(logger, logger))
+                    .exec(new ResultCallback.Adapter<Frame>() {
+                        @Override
+                        public void onNext(Frame item) {
+                            logger.print(new String(item.getPayload(), StandardCharsets.UTF_8));
+                            super.onNext(item);
+                        }
+                    })
             ) {
                 exec.awaitCompletion();
             } catch (NotFoundException ex) {
@@ -270,7 +277,7 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
         // TODO better strategy
         final long launchTime = System.currentTimeMillis();
         while (!dockerComputer.isOnline() &&
-                TimeUnit2.SECONDS.toMillis(launchTimeout) > System.currentTimeMillis() - launchTime) {
+                TimeUnit.SECONDS.toMillis(launchTimeout) > System.currentTimeMillis() - launchTime) {
             logger.println("Waiting slave connection...");
             Thread.sleep(1000);
         }
@@ -344,7 +351,7 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
 
         if (dockerSlaveTemplate.getOsType() == OsType.WINDOWS) {
             try (InputStream inStream = DockerComputerJNLPLauncher.class.getResourceAsStream("DockerComputerJNLPLauncher/init.ps1")) {
-                final String initCmd = IOUtils.toString(inStream, Charsets.UTF_8);
+                final String initCmd = IOUtils.toString(inStream, StandardCharsets.UTF_8);
                 if (initCmd == null) {
                     throw new IllegalStateException("Resource file 'init.ps1' not found");
                 }
@@ -356,7 +363,7 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
             }
         } else { // default is OsType.LINUX
             try (InputStream inStream = DockerComputerJNLPLauncher.class.getResourceAsStream("DockerComputerJNLPLauncher/init.sh")) {
-                final String initCmd = IOUtils.toString(inStream, Charsets.UTF_8);
+                final String initCmd = IOUtils.toString(inStream, StandardCharsets.UTF_8);
                 if (initCmd == null) {
                     throw new IllegalStateException("Resource file 'init.sh' not found");
                 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSingleJNLPLauncher.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/DockerComputerSingleJNLPLauncher.java
@@ -11,16 +11,16 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.Ex
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.NotFoundException;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.ExecStartResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Frame;
 import com.github.kostyasha.yad_docker_java.javax.ws.rs.ProcessingException;
-import com.google.common.base.Throwables;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.Charsets;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.slf4j.Logger;
@@ -156,7 +156,7 @@ public class DockerComputerSingleJNLPLauncher extends JNLPLauncher {
         } catch (Throwable e) {
             LOG.error("Can't launch ", e);
             listener.error("Can't launch " + e.getMessage());
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -206,7 +206,7 @@ public class DockerComputerSingleJNLPLauncher extends JNLPLauncher {
         boolean running = false;
         long launchTime = System.currentTimeMillis();
         while (!running &&
-                TimeUnit2.SECONDS.toMillis(launchTimeout) > System.currentTimeMillis() - launchTime) {
+                TimeUnit.SECONDS.toMillis(launchTimeout) > System.currentTimeMillis() - launchTime) {
             try {
                 InspectContainerResponse inspectResp = client.inspectContainerCmd(cId).exec();
                 if (isTrue(inspectResp.getState().getRunning())) {
@@ -229,7 +229,7 @@ public class DockerComputerSingleJNLPLauncher extends JNLPLauncher {
         }
 
         // now real launch
-        final String rootUrl = getJenkinsUrl(Jenkins.getInstance().getRootUrl());
+        final String rootUrl = getJenkinsUrl(Jenkins.get().getRootUrl());
 //        Objects.requireNonNull(rootUrl, "Jenkins root url is not specified!");
         if (isNull(rootUrl)) {
             listener.fatalError("Jenkins root url is not specified!");
@@ -272,10 +272,10 @@ public class DockerComputerSingleJNLPLauncher extends JNLPLauncher {
             logger.println("Starting connection command for " + cId);
             LOG.info("Starting connection command for {}", cId);
 
-            try (ExecStartResultCallback exec = client.execStartCmd(createCmdResponse.getId())
+            try (ResultCallback.Adapter<Frame> exec = client.execStartCmd(createCmdResponse.getId())
                     .withDetach(true)
                     .withTty(true)
-                    .exec(new ExecStartResultCallback())
+                    .exec(new ResultCallback.Adapter<Frame>())
             ) {
                 exec.awaitCompletion(10, SECONDS);
             } catch (NotFoundException ex) {
@@ -295,7 +295,7 @@ public class DockerComputerSingleJNLPLauncher extends JNLPLauncher {
         // TODO better strategy
         launchTime = System.currentTimeMillis();
         while (computer.isReallyOffline() &&
-                TimeUnit2.SECONDS.toMillis(launchTimeout) > System.currentTimeMillis() - launchTime) {
+                TimeUnit.SECONDS.toMillis(launchTimeout) > System.currentTimeMillis() - launchTime) {
             logger.println("Waiting slave connection...");
             Thread.sleep(1000);
         }
@@ -315,7 +315,7 @@ public class DockerComputerSingleJNLPLauncher extends JNLPLauncher {
     public void appendContainerConfig(CreateContainerCmd createContainerCmd)
             throws IOException {
         try (InputStream instream = DockerComputerJNLPLauncher.class.getResourceAsStream("DockerComputerJNLPLauncher/init.sh")) {
-            final String initCmd = IOUtils.toString(instream, Charsets.UTF_8);
+            final String initCmd = IOUtils.toString(instream, StandardCharsets.UTF_8);
             if (initCmd == null) {
                 throw new IllegalStateException("Resource file 'init.sh' not found");
             }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/ListenerLogContainerResultCallback.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/launcher/ListenerLogContainerResultCallback.java
@@ -1,11 +1,11 @@
 package com.github.kostyasha.yad.launcher;
 
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Frame;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.LogContainerResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.TaskListener;
 
-public class ListenerLogContainerResultCallback extends LogContainerResultCallback {
+public class ListenerLogContainerResultCallback extends ResultCallback.Adapter<Frame> {
     private final TaskListener listener;
 
     public ListenerLogContainerResultCallback(TaskListener listener) {

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/other/cloudorder/AsIsDockerCloudOrder.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/other/cloudorder/AsIsDockerCloudOrder.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static jenkins.model.Jenkins.getInstance;
+import static jenkins.model.Jenkins.get;
 
 public class AsIsDockerCloudOrder extends DockerCloudOrder {
 
@@ -21,7 +21,7 @@ public class AsIsDockerCloudOrder extends DockerCloudOrder {
     @Nonnull
     @Override
     public List<DockerCloud> getDockerClouds(Label label) {
-        return getInstance().clouds.stream()
+        return get().clouds.stream()
                 .filter(Objects::nonNull)
                 .filter(DockerCloud.class::isInstance)
                 .map(cloud -> (DockerCloud) cloud)

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/other/cloudorder/DockerCloudOrder.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/other/cloudorder/DockerCloudOrder.java
@@ -3,7 +3,7 @@ package com.github.kostyasha.yad.other.cloudorder;
 import com.github.kostyasha.yad.DockerCloud;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Label;
 import jenkins.model.Jenkins;
@@ -11,8 +11,7 @@ import jenkins.model.Jenkins;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public abstract class DockerCloudOrder extends AbstractDescribableImpl<DockerCloudOrder>
-        implements ExtensionPoint {
+public abstract class DockerCloudOrder implements Describable<DockerCloudOrder>, ExtensionPoint {
 
     /**
      * List of clouds that will be used for provisioning attempt one by one.
@@ -22,12 +21,12 @@ public abstract class DockerCloudOrder extends AbstractDescribableImpl<DockerClo
 
     @Override
     public DockerCloudOrderDescriptor getDescriptor() {
-        return (DockerCloudOrderDescriptor) super.getDescriptor();
+        return (DockerCloudOrderDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     public abstract static class DockerCloudOrderDescriptor extends Descriptor<DockerCloudOrder> {
         public static DescriptorExtensionList<DockerCloudOrder, DockerCloudOrderDescriptor> allDockerCloudOrderDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(DockerCloudOrder.class);
+            return Jenkins.get().getDescriptorList(DockerCloudOrder.class);
         }
     }
 

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/other/cloudorder/RandomLeastLoadedDockerCloudOrder.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/other/cloudorder/RandomLeastLoadedDockerCloudOrder.java
@@ -60,7 +60,7 @@ public class RandomLeastLoadedDockerCloudOrder extends DockerCloudOrder {
     protected List<DockerCloud> getAvailableDockerClouds(Label label) {
         return getAllDockerClouds().stream()
                 .filter(cloud ->
-                        cloud.canProvision(label) &&
+                        cloud.canProvision(new hudson.slaves.Cloud.CloudState(label, 0)) &&
                                 (countCurrentDockerSlaves(cloud) >= 0) &&
                                 (countCurrentDockerSlaves(cloud) < cloud.getContainerCap()))
                 .collect(Collectors.toList());

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerBuildImageStep.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerBuildImageStep.java
@@ -3,6 +3,7 @@ package com.github.kostyasha.yad.steps;
 import com.github.kostyasha.yad.commons.cmds.DockerBuildImage;
 import com.github.kostyasha.yad.connector.YADockerConnector;
 import hudson.FilePath;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
@@ -46,7 +47,7 @@ public class DockerBuildImageStep extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher,
                         @Nonnull TaskListener listener) throws InterruptedException, IOException {
         PrintStream llog = listener.getLogger();
         try {

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerBuildImageStepFileCallable.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerBuildImageStepFileCallable.java
@@ -5,7 +5,8 @@ import com.github.kostyasha.yad.connector.YADockerConnector;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.BuildImageCmd;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.BuildResponseItem;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.BuildImageResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.DockerClientException;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
@@ -71,20 +72,48 @@ public class DockerBuildImageStepFileCallable extends MasterToSlaveFileCallable<
         return null;
     }
 
-    private static class MyBuildImageResultCallback extends BuildImageResultCallback {
+    private static class MyBuildImageResultCallback extends ResultCallback.Adapter<BuildResponseItem> {
         private final PrintStream llog;
+        private String imageId;
+        private DockerClientException error;
 
         MyBuildImageResultCallback(PrintStream llog) {
             this.llog = llog;
         }
 
+        @Override
         public void onNext(BuildResponseItem item) {
+            if (item.isBuildSuccessIndicated()) {
+                this.imageId = item.getImageId();
+            } else if (item.isErrorIndicated()) {
+                this.error = new DockerClientException("Could not build image: " + item.getErrorDetail().getMessage());
+            }
             String text = item.getStream();
             if (nonNull(text)) {
                 llog.print(text);
                 LOG.debug(text);
             }
             super.onNext(item);
+        }
+
+        public String awaitImageId() {
+            try {
+                awaitCompletion();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new DockerClientException("Interrupted while building image", e);
+            }
+            return getImageId();
+        }
+
+        private String getImageId() {
+            if (error != null) {
+                throw error;
+            }
+            if (imageId != null) {
+                return imageId;
+            }
+            throw new DockerClientException("Could not build image");
         }
     }
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerImageCleanupFileCallable.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerImageCleanupFileCallable.java
@@ -3,7 +3,6 @@ package com.github.kostyasha.yad.steps;
 import com.github.kostyasha.yad.connector.YADockerConnector;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.DockerClient;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.NotFoundException;
-import com.google.common.base.Throwables;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
@@ -40,10 +39,8 @@ public class DockerImageCleanupFileCallable extends MasterToSlaveFileCallable<Vo
         try (DockerClient client = connector.getClient()) {
             return invoke(client);
         } catch (Exception ex) {
-            Throwables.propagate(ex);
+            throw new RuntimeException(ex);
         }
-
-        return null;
     }
 
     private Void invoke(DockerClient client) {

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerImageComboStep.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerImageComboStep.java
@@ -5,6 +5,7 @@ import com.github.kostyasha.yad.connector.YADockerConnector;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.FilePath;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
@@ -101,7 +102,7 @@ public class DockerImageComboStep extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher,
                         @Nonnull TaskListener listener) throws InterruptedException, IOException {
         PrintStream llog = listener.getLogger();
         final DockerImageComboStepFileCallable comboCallable = newDockerImageComboStepFileCallableBuilder()

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerImageComboStepFileCallable.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerImageComboStepFileCallable.java
@@ -13,9 +13,8 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Auth
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.BuildResponseItem;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.PushResponseItem;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.NameParser;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.BuildImageResultCallback;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.PushImageResultCallback;
-import com.google.common.base.Throwables;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.DockerClientException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.model.Run;
@@ -165,10 +164,8 @@ public class DockerImageComboStepFileCallable extends MasterToSlaveFileCallable<
         try (DockerClient client = connector.getClient()) {
             return invoke(client);
         } catch (Exception ex) {
-            Throwables.propagate(ex);
+            throw new RuntimeException(ex);
         }
-
-        return null;
     }
 
     /**
@@ -292,7 +289,7 @@ public class DockerImageComboStepFileCallable extends MasterToSlaveFileCallable<
         }
     }
 
-    private static class MyBuildImageResultCallback extends BuildImageResultCallback {
+    private static class MyBuildImageResultCallback extends ResultCallback.Adapter<BuildResponseItem> {
         private static final String RUNNING_IN = "---> Running in";
         private static final String IN = "--->";
         private static final String REMOVING = "Removing intermediate container";
@@ -300,6 +297,8 @@ public class DockerImageComboStepFileCallable extends MasterToSlaveFileCallable<
 
         private final PrintStream llog;
         private final Set<String> containers = new HashSet<>();
+        private String imageId;
+        private DockerClientException error;
 
         MyBuildImageResultCallback(PrintStream llog) {
             this.llog = llog;
@@ -309,7 +308,28 @@ public class DockerImageComboStepFileCallable extends MasterToSlaveFileCallable<
             return containers;
         }
 
+        public String awaitImageId() {
+            try {
+                awaitCompletion();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new DockerClientException("Interrupted while building image", e);
+            }
+            if (error != null) {
+                throw error;
+            }
+            if (imageId != null) {
+                return imageId;
+            }
+            throw new DockerClientException("Could not build image");
+        }
+
         public void onNext(BuildResponseItem item) {
+            if (item.isBuildSuccessIndicated()) {
+                this.imageId = item.getImageId();
+            } else if (item.isErrorIndicated()) {
+                this.error = new DockerClientException("Could not build image: " + item.getErrorDetail().getMessage());
+            }
             String text = item.getStream();
             if (nonNull(text)) {
                 llog.print(text);
@@ -348,7 +368,7 @@ public class DockerImageComboStepFileCallable extends MasterToSlaveFileCallable<
         }
     }
 
-    private class MyPushImageResultCallback extends PushImageResultCallback {
+    private class MyPushImageResultCallback extends ResultCallback.Adapter<PushResponseItem> {
         @Override
         public void onNext(PushResponseItem item) {
             printResponseItemToListener(taskListener, item);

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerShellStep.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/steps/DockerShellStep.java
@@ -13,8 +13,8 @@ import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.command.St
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.DockerException;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.NotFoundException;
 import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.Frame;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.AttachContainerResultCallback;
-import com.github.kostyasha.yad_docker_java.com.github.dockerjava.core.command.WaitContainerResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.async.ResultCallback;
+import com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.model.WaitResponse;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -127,7 +127,7 @@ public class DockerShellStep extends Builder implements SimpleBuildStep {
 
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher,
                         @Nonnull TaskListener listener) throws InterruptedException, IOException {
         PrintStream llog = listener.getLogger();
         final String imageId = containerLifecycle.getImage();
@@ -232,7 +232,7 @@ public class DockerShellStep extends Builder implements SimpleBuildStep {
                 LOG.debug("Start container '{}', for '{}'", cId, run.getDisplayName());
 
                 // attach cmd
-                try (AttachContainerResultCallback callback = new MyAttachContainerResultCallback(llog)) {
+                try (MyAttachContainerResultCallback callback = new MyAttachContainerResultCallback(llog)) {
                     longClient.attachContainerCmd(cId)
                             .withStdErr(true)
                             .withStdOut(true)
@@ -240,7 +240,7 @@ public class DockerShellStep extends Builder implements SimpleBuildStep {
                             .withLogs(true)
                             .exec(callback);
 
-                    WaitContainerResultCallback waitCallback = new WaitContainerResultCallback();
+                    MyWaitContainerResultCallback waitCallback = new MyWaitContainerResultCallback();
                     longClient.waitContainerCmd(cId).exec(waitCallback);
                     final Integer statusCode = waitCallback.awaitStatusCode();
                     callback.awaitCompletion(1, TimeUnit.SECONDS);
@@ -316,7 +316,7 @@ public class DockerShellStep extends Builder implements SimpleBuildStep {
                 // exclude executor computer related vars
                 envVars.put("BUILD_DISPLAY_NAME", run.getDisplayName());
 
-                String rootUrl = Jenkins.getInstance().getRootUrl();
+                String rootUrl = Jenkins.get().getRootUrl();
                 if (rootUrl != null) {
                     envVars.put("BUILD_URL", rootUrl + run.getUrl());
                 }
@@ -364,7 +364,7 @@ public class DockerShellStep extends Builder implements SimpleBuildStep {
         }
     }
 
-    public static class MyAttachContainerResultCallback extends AttachContainerResultCallback {
+    public static class MyAttachContainerResultCallback extends ResultCallback.Adapter<Frame> {
         private final PrintStream llog;
 
         public MyAttachContainerResultCallback(PrintStream llog) {
@@ -375,6 +375,27 @@ public class DockerShellStep extends Builder implements SimpleBuildStep {
         public void onNext(Frame frame) {
             super.onNext(frame);
             llog.println(new String(frame.getPayload(), UTF_8).trim());
+        }
+    }
+
+    private static class MyWaitContainerResultCallback extends ResultCallback.Adapter<WaitResponse> {
+        private WaitResponse waitResponse;
+
+        @Override
+        public void onNext(WaitResponse item) {
+            this.waitResponse = item;
+            super.onNext(item);
+        }
+
+        public Integer awaitStatusCode() {
+            try {
+                awaitCompletion();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new com.github.kostyasha.yad_docker_java.com.github.dockerjava.api.exception.DockerClientException(
+                        "Interrupted while waiting for container", e);
+            }
+            return waitResponse == null ? null : waitResponse.getStatusCode();
         }
     }
 }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/strategy/DockerCloudRetentionStrategy.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/strategy/DockerCloudRetentionStrategy.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 
-import static hudson.util.TimeUnit2.MINUTES;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * {@link CloudRetentionStrategy} that has Descriptor and UI with description

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/strategy/DockerOnceRetentionStrategy.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/strategy/DockerOnceRetentionStrategy.java
@@ -13,7 +13,7 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.RetentionStrategy;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.jenkinsci.plugins.durabletask.executors.ContinuableExecutable;
@@ -61,7 +61,7 @@ public class DockerOnceRetentionStrategy extends CloudRetentionStrategy implemen
         // terminate. If it's not already trying to terminate then lets terminate manually.
         if (acc.isIdle() && !disabled) {
             final long idleMilliseconds = System.currentTimeMillis() - acc.getIdleStartMilliseconds();
-            if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleMinutes)) {
+            if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleMinutes)) {
                 LOG.debug("Disconnecting {}", acc.getName());
                 done(acc);
             }

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerFunctions.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerFunctions.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static jenkins.model.Jenkins.getInstance;
+import static jenkins.model.Jenkins.get;
 
 /**
  * UI helper class.
@@ -36,7 +36,7 @@ public class DockerFunctions {
     @SuppressWarnings("rawtypes")
     public static List<NodePropertyDescriptor> getNodePropertyDescriptors(Class<? extends Node> clazz) {
         List<NodePropertyDescriptor> result = new ArrayList<>();
-        Collection<NodePropertyDescriptor> list = (Collection) Jenkins.getInstance().getDescriptorList(NodeProperty.class);
+        Collection<NodePropertyDescriptor> list = (Collection) Jenkins.get().getDescriptorList(NodeProperty.class);
         for (NodePropertyDescriptor npd : list) {
             if (npd.isApplicable(clazz)) {
                 result.add(npd);
@@ -58,9 +58,9 @@ public class DockerFunctions {
     public static List<Descriptor<ComputerLauncher>> getDockerComputerLauncherDescriptors() {
         List<Descriptor<ComputerLauncher>> launchers = new ArrayList<>();
 
-        launchers.add(getInstance().getDescriptor(DockerComputerSSHLauncher.class));
-        launchers.add(getInstance().getDescriptor(DockerComputerJNLPLauncher.class));
-        launchers.add(getInstance().getDescriptor(DockerComputerIOLauncher.class));
+        launchers.add(get().getDescriptor(DockerComputerSSHLauncher.class));
+        launchers.add(get().getDescriptor(DockerComputerJNLPLauncher.class));
+        launchers.add(get().getDescriptor(DockerComputerIOLauncher.class));
 
         return launchers;
     }
@@ -71,9 +71,9 @@ public class DockerFunctions {
     public static List<Descriptor<RetentionStrategy<?>>> getDockerRetentionStrategyDescriptors() {
         List<Descriptor<RetentionStrategy<?>>> strategies = new ArrayList<>();
 
-        strategies.add(getInstance().getDescriptor(DockerOnceRetentionStrategy.class));
-        strategies.add(getInstance().getDescriptor(DockerCloudRetentionStrategy.class));
-        strategies.add(getInstance().getDescriptor(DockerComputerIOLauncher.class));
+        strategies.add(get().getDescriptor(DockerOnceRetentionStrategy.class));
+        strategies.add(get().getDescriptor(DockerCloudRetentionStrategy.class));
+        strategies.add(get().getDescriptor(DockerComputerIOLauncher.class));
 
         return strategies;
     }
@@ -86,7 +86,7 @@ public class DockerFunctions {
      */
     @Nonnull
     public static List<DockerCloud> getAllDockerClouds() {
-        return getInstance().clouds.stream()
+        return get().clouds.stream()
                 .filter(Objects::nonNull)
                 .filter(DockerCloud.class::isInstance)
                 .map(cloud -> (DockerCloud) cloud)

--- a/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerUtils.java
+++ b/yet-another-docker-plugin/src/main/java/com/github/kostyasha/yad/utils/DockerUtils.java
@@ -20,7 +20,7 @@ public class DockerUtils {
 
         while (retries >= 0) {
             try {
-                Jenkins.getInstance().addNode(slave);
+                Jenkins.get().addNode(slave);
                 return;
             } catch (IOException ex) {
                 lastException = ex;

--- a/yet-another-docker-plugin/src/main/resources/index.jelly
+++ b/yet-another-docker-plugin/src/main/resources/index.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Yet Another Docker plugin. Provides Docker cloud provisioning: dynamically
+    starts build agents in Docker containers and removes them when they are no
+    longer needed.
+</div>

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/DockerCloudTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/DockerCloudTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.github.kostyasha.yad.commons.DockerContainerRestartPolicy;
 import com.github.kostyasha.yad.commons.DockerCreateContainer;
+import hudson.util.Secret;
 import com.github.kostyasha.yad.commons.DockerImagePullStrategy;
 import com.github.kostyasha.yad.commons.DockerPullImage;
 import com.github.kostyasha.yad.commons.DockerRemoveContainer;
@@ -65,7 +66,7 @@ public class DockerCloudTest {
                     CredentialsScope.GLOBAL, // scope
                     null, // id
                     "description", //desc
-                    "keypem",
+                    Secret.fromString("keypem"),
                     "certpem",
                     "capem"
             );
@@ -80,7 +81,6 @@ public class DockerCloudTest {
             connector.setReadTimeout(1002);
 
             final DockerPullImage pullImage = new DockerPullImage();
-            pullImage.setCredentialsId("");
             pullImage.setPullStrategy(DockerImagePullStrategy.PULL_ALWAYS);
 
             final DockerComputerJNLPLauncher launcher = new DockerComputerJNLPLauncher();
@@ -147,12 +147,12 @@ public class DockerCloudTest {
             dockerSlaveTemplates.add(dockerSlaveTemplate);
             before = new DockerCloud("docker-cloud", dockerSlaveTemplates, 17, connector);
 
-            j.getInstance().clouds.add(before);
-            j.getInstance().save();
+            j.jenkins.clouds.add(before);
+            j.jenkins.save();
 
             j.configRoundtrip();
 
-            after = (DockerCloud) j.getInstance().getCloud("docker-cloud");
+            after = (DockerCloud) j.jenkins.getCloud("docker-cloud");
         }
     }
 

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/DockerProvisioningStrategyTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/DockerProvisioningStrategyTest.java
@@ -7,11 +7,11 @@ import hudson.slaves.RetentionStrategy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.github.kostyasha.yad.DockerProvisioningStrategy.notAllowedStrategy;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/step/DockerTask.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/step/DockerTask.java
@@ -4,30 +4,20 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.ResourceList;
-import hudson.model.queue.AbstractQueueTask;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
-import org.acegisecurity.AccessDeniedException;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * @author Kanstantsin Shautsou
  */
-public class DockerTask extends AbstractQueueTask implements Queue.TransientTask, AccessControlled {
-    @Override
-    public boolean isBuildBlocked() {
-        return false;
-    }
-
-    @Override
-    public String getWhyBlocked() {
-        return null;
-    }
-
+public class DockerTask implements Queue.TransientTask, AccessControlled {
     @Override
     public String getName() {
         return "Some name";
@@ -68,11 +58,6 @@ public class DockerTask extends AbstractQueueTask implements Queue.TransientTask
     }
 
     @Override
-    public Node getLastBuiltOn() {
-        return null;
-    }
-
-    @Override
     public long getEstimatedDuration() {
         return -1;
     }
@@ -82,14 +67,24 @@ public class DockerTask extends AbstractQueueTask implements Queue.TransientTask
         return new MyExecutable(this);
     }
 
-    @Nonnull
     @Override
-    public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getRootACL();
+    public Collection<? extends hudson.model.queue.SubTask> getSubTasks() {
+        return Collections.singleton(this);
     }
 
     @Override
-    public void checkPermission(@Nonnull Permission permission) throws AccessDeniedException {
+    public hudson.model.Queue.Task getOwnerTask() {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public ACL getACL() {
+        return Jenkins.get().getAuthorizationStrategy().getRootACL();
+    }
+
+    @Override
+    public void checkPermission(@Nonnull Permission permission) {
         getACL().checkPermission(permission);
     }
 

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/step/TaskBuildStep.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/step/TaskBuildStep.java
@@ -2,6 +2,7 @@ package com.github.kostyasha.yad.step;
 
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.Queue;
@@ -30,7 +31,7 @@ public class TaskBuildStep extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher,
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull EnvVars env, @Nonnull Launcher launcher,
                         @Nonnull TaskListener taskListener) throws InterruptedException, IOException {
         taskListener.getLogger().println("Entering task producer");
         Queue.getInstance().schedule(new DockerTask(), 0);

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/steps/DockerBuildImageStepTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/steps/DockerBuildImageStepTest.java
@@ -29,7 +29,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.File;
 
 import static com.github.kostyasha.yad.other.ConnectorType.JERSEY;
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -69,7 +69,7 @@ public class DockerBuildImageStepTest {
         );
         final DumbSlave dumbSlave = new DumbSlave("docker-daemon", "/home/vagrant/jenkins2", sshLauncher);
         jRule.getInstance().addNode(dumbSlave);
-        await().timeout(60, SECONDS).until(() -> assertThat(dumbSlave.getChannel(), notNullValue()));
+        await().atMost(60, SECONDS).untilAsserted(() -> assertThat(dumbSlave.getChannel(), notNullValue()));
         String dockerfilePath = dumbSlave.getChannel().call(new StringThrowableCallable());
 
 
@@ -118,7 +118,7 @@ public class DockerBuildImageStepTest {
                     "RUN mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app -DarchetypeArtifactId=maven-archetype-quickstart -DarchetypeVersion=1.4 -DinteractiveMode=false\n" +
                     "RUN cd my-app && mvn install\n"
                     ;
-            FileUtils.writeStringToFile(dockerfile, dockerfileContent);
+            FileUtils.writeStringToFile(dockerfile, dockerfileContent, java.nio.charset.StandardCharsets.UTF_8);
             return tempFolder.getAbsolutePath();
         }
     }

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/steps/DockerImageComboStepTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/steps/DockerImageComboStepTest.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.util.Collections;
 
 import static com.github.kostyasha.yad.other.ConnectorType.JERSEY;
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -88,7 +88,7 @@ public class DockerImageComboStepTest {
         );
         final DumbSlave dumbSlave = new DumbSlave("docker-daemon", "/home/vagrant/jenkins2", sshLauncher);
         jRule.getInstance().addNode(dumbSlave);
-        await().timeout(60, SECONDS).until(() -> assertThat(dumbSlave.getChannel(), notNullValue()));
+        await().atMost(60, SECONDS).untilAsserted(() -> assertThat(dumbSlave.getChannel(), notNullValue()));
         String dockerfilePath = dumbSlave.getChannel().call(new StringThrowableCallable());
 
 
@@ -133,7 +133,7 @@ public class DockerImageComboStepTest {
             File tempFolder = new File("/home/vagrant/jenkins2/docker");
             File dockerfile = new File(tempFolder, "Dockerfile");
             String dockerfileContent = "FROM busybox\nRUN echo hello";
-            FileUtils.writeStringToFile(dockerfile, dockerfileContent);
+            FileUtils.writeStringToFile(dockerfile, dockerfileContent, java.nio.charset.StandardCharsets.UTF_8);
             return tempFolder.getAbsolutePath();
         }
     }

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/steps/DockerShellStepIT.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/steps/DockerShellStepIT.java
@@ -22,7 +22,7 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static com.github.kostyasha.yad.other.ConnectorType.JERSEY;
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -62,7 +62,7 @@ public class DockerShellStepIT {
         );
         final DumbSlave dumbSlave = new DumbSlave("docker-daemon", "/home/vagrant/jenkins2", sshLauncher);
         jRule.getInstance().addNode(dumbSlave);
-        await().timeout(60, SECONDS).until(() -> assertThat(dumbSlave.getChannel(), notNullValue()));
+        await().atMost(60, SECONDS).untilAsserted(() -> assertThat(dumbSlave.getChannel(), notNullValue()));
 //        String dockerfilePath = dumbSlave.getChannel().call(new DockerBuildImageStepTest.StringThrowableCallable());
 
 

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/utils/DockerCloudLoadComparatorTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/utils/DockerCloudLoadComparatorTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**

--- a/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/utils/PortUtilsTest.java
+++ b/yet-another-docker-plugin/src/test/java/com/github/kostyasha/yad/utils/PortUtilsTest.java
@@ -2,7 +2,6 @@ package com.github.kostyasha.yad.utils;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
@@ -20,6 +19,7 @@ import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThrows;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -32,9 +32,6 @@ public class    PortUtilsTest {
 
     @Rule
     public SomeServerRule server = new SomeServerRule();
-
-    @Rule
-    public ExpectedException ex = ExpectedException.none();
 
     @Test
     public void shouldConnectToServerSuccessfully() throws Exception {
@@ -58,22 +55,18 @@ public class    PortUtilsTest {
 
     @Test
     public void shouldThrowIllegalStateExOnNotAvailPort() throws Exception {
-        ex.expect(IllegalStateException.class);
-        create("localhost", 0).withRetries(RETRY_COUNT).bySshWithEveryRetryWaitFor(DELAY, MILLISECONDS);
+        assertThrows(IllegalStateException.class, () ->
+                create("localhost", 0).withRetries(RETRY_COUNT).bySshWithEveryRetryWaitFor(DELAY, MILLISECONDS));
     }
 
     @Test
     public void shouldWaitIfPortAvailableButNotSshUntilTimeoutAndThrowEx() throws Exception {
-        ex.expect(IOException.class);
         long before = currentTimeMillis();
-        try {
-            create(server.host(), server.port()).withRetries(RETRY_COUNT)
-                    .bySshWithEveryRetryWaitFor(RETRY_DELAY, MILLISECONDS);
-        } catch (IOException e) {
-            assertThat("Should wait for timeout", new Date(currentTimeMillis()),
-                    greaterThanOrEqualTo(new Date(before + RETRY_COUNT * RETRY_DELAY)));
-            throw e;
-        }
+        assertThrows(IOException.class, () ->
+                create(server.host(), server.port()).withRetries(RETRY_COUNT)
+                        .bySshWithEveryRetryWaitFor(RETRY_DELAY, MILLISECONDS));
+        assertThat("Should wait for timeout", new Date(currentTimeMillis()),
+                greaterThanOrEqualTo(new Date(before + RETRY_COUNT * RETRY_DELAY)));
     }
 
     @Test

--- a/yet-another-docker-plugin/src/test/java/org/jvnet/hudson/test/DockerSimpleBuildWrapperTest.java
+++ b/yet-another-docker-plugin/src/test/java/org/jvnet/hudson/test/DockerSimpleBuildWrapperTest.java
@@ -10,25 +10,11 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.Shell;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.webapp.Configuration;
-import org.eclipse.jetty.webapp.WebAppContext;
-import org.eclipse.jetty.webapp.WebXmlConfiguration;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletContext;
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static com.github.kostyasha.yad.other.ConnectorType.JERSEY;
 
@@ -42,46 +28,7 @@ public class DockerSimpleBuildWrapperTest {
     private static final String ADDRESS = "192.168.1.3";
 
     @Rule
-    public JenkinsRule jRule = new JenkinsRule() {
-        @Override
-        public URL getURL() throws IOException {
-            return new URL("http://" + ADDRESS + ":" + localPort + contextPath + "/");
-        }
-
-        @Override
-        protected ServletContext createWebServer() throws Exception {
-            server = new Server(new ThreadPoolImpl(new ThreadPoolExecutor(10, 10, 10L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), r -> {
-                Thread t = new Thread(r);
-                t.setName("Jetty Thread Pool");
-                return t;
-            })));
-
-            WebAppContext context = new WebAppContext(WarExploder.getExplodedDir().getPath(), contextPath);
-            context.setClassLoader(getClass().getClassLoader());
-            context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
-            context.addBean(new NoListenerConfiguration(context));
-            server.setHandler(context);
-            context.setMimeTypes(MIME_TYPES);
-            context.getSecurityHandler().setLoginService(configureUserRealm());
-            context.setResourceBase(WarExploder.getExplodedDir().getPath());
-
-            ServerConnector connector = new ServerConnector(server);
-            HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration();
-            // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL
-            config.setRequestHeaderSize(12 * 1024);
-            connector.setHost(ADDRESS);
-            if (System.getProperty("port") != null)
-                connector.setPort(Integer.parseInt(System.getProperty("port")));
-
-            server.addConnector(connector);
-            server.start();
-
-            localPort = connector.getLocalPort();
-            LOG.info("Running on {}", getURL());
-
-            return context.getServletContext();
-        }
-    };
+    public JenkinsRule jRule = new JenkinsRule();
 
     @Ignore("For local experiments")
     @Test


### PR DESCRIPTION
This plugin is listed as using a detached plugin which is going to be removed from the Jenkins war soon: https://github.com/jenkinsci/jenkins/pull/27129

It won't stop working for newer instances or anyone installing it fresh but if anyone upgrades from <2.112, <2.184  the required plugins won't be installed.

This is AI assisted.

@KostyaSha can this be reviewed please?